### PR TITLE
Add dev-spec-publisher skill and automation scripts

### DIFF
--- a/.claude/skills/dev-spec-publisher/SKILL.md
+++ b/.claude/skills/dev-spec-publisher/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: dev-spec-publisher
+description: Generate a development specification (dev spec) for one or more PRs by analyzing their diffs, titles, and bodies using GitHub Actions automation.
+---
+
+When invoked as:
+
+    /publish-dev-spec publish dev spec for PR #<number> [and PR #<number2> ...]
+
+or
+
+    /publish-dev-spec publish dev spec for PRs #<number1>, #<number2>, ...
+
+do the following:
+
+1. Use GitHub Actions to:
+   - Fetch the details (title, body, diff, linked issues, etc.) for all specified PR numbers.
+   - Summarize the combined scope, changes, risks, and validation steps from all PRs.
+   - Auto-generate a dev spec markdown file (e.g., DEV_SPEC_PR_<number1>_<number2>_...md) with:
+     - PR titles and summaries
+     - Linked issues
+     - Combined scope and user stories (from PRs or linked issues)
+     - Implementation summary (from diffs and PR bodies)
+     - Risks/assumptions
+     - Validation/acceptance criteria
+2. Commit the dev spec file to a new branch (e.g., dev-spec/pr-<number1>-<number2>-...).
+3. Open a PR for the dev spec file, referencing all original PRs.
+
+This skill is fully automated via GitHub Actions and does not require local scripts. The workflow will:
+- Trigger on workflow_dispatch with one or more PR numbers as input
+- Use the GitHub API to fetch PR details and diffs
+- Generate the dev spec markdown
+- Commit and push to a new branch
+- Open a PR for the dev spec
+
+See automation/scripts/dev_spec_from_pr.sh for implementation details (supports multiple PRs).

--- a/.claude/skills/dev-spec-publisher/SKILL.md
+++ b/.claude/skills/dev-spec-publisher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-spec-publisher
-description: Generate a development specification (dev spec) for one or more PRs by analyzing their diffs, titles, and bodies using GitHub Actions automation.
+description: Generate a draft development specification for one or more PRs using automation/scripts/publish_dev_spec_from_pr.sh and automation/scripts/dev_spec_from_pr.sh; operator review and completion of risks/validation are required before publishing.
 ---
 
 When invoked as:
@@ -13,27 +13,31 @@ or
 
 do the following:
 
-1. Before creating the dev spec, create a tracking issue in `Gradient/GradientV1` (or a configured issue repo) describing the PR(s) that will be covered.
+1. Before creating the dev spec, create a tracking issue in a configured issue repo (defaults to the source repo when not provided) describing the PR(s) that will be covered.
 2. Use GitHub Actions to:
-   - Fetch the details (title, body, diff, linked issues, etc.) for all specified PR numbers.
-   - Summarize the combined scope, changes, risks, and validation steps from all PRs.
-   - Auto-generate a dev spec markdown file (e.g., DEV_SPEC_PR_<number1>_<number2>_...md) with:
-    - Tracking issue URL
-     - PR titles and summaries
-     - Linked issues
-     - Combined scope and user stories (from PRs or linked issues)
-     - Implementation summary (from diffs and PR bodies)
-     - Risks/assumptions
-     - Validation/acceptance criteria
+     - Fetch the details (title, body, diff, linked issues, etc.) for all specified PR numbers.
+     - Summarize the combined scope, changes, risks, and validation steps from all PRs.
+     - Auto-generate a dev spec markdown file (e.g., DEV_SPEC_PR_<number1>_<number2>_...md) with:
+         - Tracking issue URL
+         - PR titles and summaries
+         - Linked issues
+         - Combined scope and user stories (from PRs or linked issues)
+         - Implementation summary (from diffs and PR bodies)
+         - Risks/assumptions
+         - Validation/acceptance criteria
 3. Commit the dev spec file to a new branch (e.g., dev-spec/pr-<number1>-<number2>-...).
 4. Open a PR for the dev spec file, referencing all original PRs and the tracking issue.
 
-This skill is fully automated via GitHub Actions and does not require local scripts. The workflow will:
+This skill runs script-driven automation and produces a draft that requires operator verification. The workflow will:
 - Trigger on workflow_dispatch with one or more PR numbers as input
-- Create the tracking issue in `Gradient/GradientV1` first
+- Create the tracking issue in the configured issue repo first
 - Use the GitHub API to fetch PR details and diffs
-- Generate the dev spec markdown
+- Generate a draft dev spec markdown
 - Commit and push to a new branch
-- Open a PR for the dev spec
+- Open a PR for the dev spec draft
+
+Before publishing, manually verify and complete:
+- Risks / assumptions
+- Validation / acceptance criteria
 
 See [automation/scripts/publish_dev_spec_from_pr.sh](automation/scripts/publish_dev_spec_from_pr.sh), [automation/scripts/dev_spec_from_pr.sh](automation/scripts/dev_spec_from_pr.sh), and [.github/workflows/publish_dev_spec_from_pr.yml](.github/workflows/publish_dev_spec_from_pr.yml).

--- a/.claude/skills/dev-spec-publisher/SKILL.md
+++ b/.claude/skills/dev-spec-publisher/SKILL.md
@@ -13,24 +13,27 @@ or
 
 do the following:
 
-1. Use GitHub Actions to:
+1. Before creating the dev spec, create a tracking issue in `Gradient/GradientV1` (or a configured issue repo) describing the PR(s) that will be covered.
+2. Use GitHub Actions to:
    - Fetch the details (title, body, diff, linked issues, etc.) for all specified PR numbers.
    - Summarize the combined scope, changes, risks, and validation steps from all PRs.
    - Auto-generate a dev spec markdown file (e.g., DEV_SPEC_PR_<number1>_<number2>_...md) with:
+    - Tracking issue URL
      - PR titles and summaries
      - Linked issues
      - Combined scope and user stories (from PRs or linked issues)
      - Implementation summary (from diffs and PR bodies)
      - Risks/assumptions
      - Validation/acceptance criteria
-2. Commit the dev spec file to a new branch (e.g., dev-spec/pr-<number1>-<number2>-...).
-3. Open a PR for the dev spec file, referencing all original PRs.
+3. Commit the dev spec file to a new branch (e.g., dev-spec/pr-<number1>-<number2>-...).
+4. Open a PR for the dev spec file, referencing all original PRs and the tracking issue.
 
 This skill is fully automated via GitHub Actions and does not require local scripts. The workflow will:
 - Trigger on workflow_dispatch with one or more PR numbers as input
+- Create the tracking issue in `Gradient/GradientV1` first
 - Use the GitHub API to fetch PR details and diffs
 - Generate the dev spec markdown
 - Commit and push to a new branch
 - Open a PR for the dev spec
 
-See automation/scripts/dev_spec_from_pr.sh for implementation details (supports multiple PRs).
+See [automation/scripts/publish_dev_spec_from_pr.sh](automation/scripts/publish_dev_spec_from_pr.sh), [automation/scripts/dev_spec_from_pr.sh](automation/scripts/dev_spec_from_pr.sh), and [.github/workflows/publish_dev_spec_from_pr.yml](.github/workflows/publish_dev_spec_from_pr.yml).

--- a/.github/workflows/publish_dev_spec_from_pr.yml
+++ b/.github/workflows/publish_dev_spec_from_pr.yml
@@ -1,0 +1,49 @@
+name: Publish Dev Spec from PR(s)
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_repo:
+        description: 'Source repo for PRs (owner/name), e.g. KesterTan/GradienceV2'
+        required: true
+        default: 'KesterTan/GradienceV2'
+        type: string
+      pr_numbers:
+        description: 'Comma-separated PR numbers (e.g. 12,15,18)'
+        required: true
+        type: string
+      issue_repo:
+        description: 'Tracking issue repo (owner/name), default Gradient/GradientV1'
+        required: false
+        default: 'Gradient/GradientV1'
+        type: string
+
+jobs:
+  generate-dev-spec:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Make scripts executable
+        run: chmod +x automation/scripts/dev_spec_from_pr.sh automation/scripts/publish_dev_spec_from_pr.sh
+
+      - name: Generate and publish dev spec
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          automation/scripts/publish_dev_spec_from_pr.sh \
+            "${{ github.event.inputs.source_repo }}" \
+            "${{ github.event.inputs.pr_numbers }}" \
+            "${{ github.event.inputs.issue_repo }}"

--- a/.github/workflows/publish_dev_spec_from_pr.yml
+++ b/.github/workflows/publish_dev_spec_from_pr.yml
@@ -13,9 +13,9 @@ on:
         required: true
         type: string
       issue_repo:
-        description: 'Tracking issue repo (owner/name), default Gradient/GradientV1'
+        description: 'Optional tracking issue repo (owner/name). If omitted, uses source_repo.'
         required: false
-        default: 'Gradient/GradientV1'
+        default: ''
         type: string
 
 jobs:
@@ -43,7 +43,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          automation/scripts/publish_dev_spec_from_pr.sh \
-            "${{ github.event.inputs.source_repo }}" \
-            "${{ github.event.inputs.pr_numbers }}" \
-            "${{ github.event.inputs.issue_repo }}"
+          if [[ -n "${{ github.event.inputs.issue_repo }}" ]]; then
+            automation/scripts/publish_dev_spec_from_pr.sh \
+              "${{ github.event.inputs.source_repo }}" \
+              "${{ github.event.inputs.pr_numbers }}" \
+              "${{ github.event.inputs.issue_repo }}"
+          else
+            automation/scripts/publish_dev_spec_from_pr.sh \
+              "${{ github.event.inputs.source_repo }}" \
+              "${{ github.event.inputs.pr_numbers }}"
+          fi

--- a/automation/scripts/dev_spec_from_pr.sh
+++ b/automation/scripts/dev_spec_from_pr.sh
@@ -1,87 +1,107 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./dev_spec_from_pr.sh <pr_json> <pr_diff>
-# Expects pr_json (from gh pr view --json ...) and pr_diff (from gh pr diff)
+# Usage:
+#   ./dev_spec_from_pr.sh <pr_json> <pr_diff> [tracking_issue_url]
+#
+# Inputs:
+# - pr_json: JSON file containing either:
+#   a) a single PR object, or
+#   b) an array of PR objects
+# - pr_diff: combined diff text file
+# - tracking_issue_url: optional issue URL created before dev-spec generation
 
 if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <pr_json> <pr_diff>"
+  echo "Usage: $0 <pr_json> <pr_diff> [tracking_issue_url]"
   exit 1
 fi
 
 PR_JSON="$1"
 PR_DIFF="$2"
+TRACKING_ISSUE_URL="${3:-}"
 
-# Check if PR_JSON is an array (multi-PR) or single object
-if jq -e 'type == "array"' "$PR_JSON" >/dev/null; then
-  PR_NUMS=$(jq -r '.[].number' "$PR_JSON" | paste -sd '_' -)
-  DEV_SPEC_FILE="DEV_SPEC_PR_${PR_NUMS}.md"
-  {
-    echo "# Development Specification — PRs $(jq -r '.[].number' "$PR_JSON" | paste -sd ', ' -)"
-    echo
-    echo "## 0) Scope / PR summaries"
-    PR_COUNT=$(jq 'length' "$PR_JSON")
-    for i in $(seq 0 $((PR_COUNT-1))); do
-      PR_TITLE=$(jq -r ".[$i].title" "$PR_JSON")
-      PR_AUTHOR=$(jq -r ".[$i].author.login" "$PR_JSON")
-      PR_LINKED_ISSUES=$(jq -r ".[$i].linkedIssues[]?.number" "$PR_JSON" | xargs -I{} echo "#{}" | paste -sd ", " -)
-      PR_BODY=$(jq -r ".[$i].body" "$PR_JSON")
-      PR_NUM=$(jq -r ".[$i].number" "$PR_JSON")
-      echo "### PR #$PR_NUM"
-      echo "- **Title:** $PR_TITLE"
-      echo "- **Author:** $PR_AUTHOR"
-      echo "- **Linked issues:** ${PR_LINKED_ISSUES:-None}"
-      echo
-      echo "**Summary:**"
-      echo "$PR_BODY"
-      echo
-    done
-    echo '---'
-    echo '## 1) Diff Summary'
-    echo '```
-'$(head -n 80 "$PR_DIFF")'
-```
-'
-    echo '---'
-    echo '## 2) Risks / Assumptions'
-    echo '(Add risks or assumptions here based on PR bodies or code changes)'
-    echo '---'
-    echo '## 3) Validation / Acceptance Criteria'
-    echo '(Add validation steps or acceptance criteria here)'
-  } > "$DEV_SPEC_FILE"
-else
-  PR_NUM=$(jq -r '.number' "$PR_JSON")
-  PR_TITLE=$(jq -r '.title' "$PR_JSON")
-  PR_BODY=$(jq -r '.body' "$PR_JSON")
-  PR_AUTHOR=$(jq -r '.author.login' "$PR_JSON")
-  PR_LINKED_ISSUES=$(jq -r '.linkedIssues[]?.number' "$PR_JSON" | xargs -I{} echo "#{}" | paste -sd ", " -)
-  cat > DEV_SPEC_PR_${PR_NUM}.md <<EOF
-# Development Specification — PR #${PR_NUM}
-
-## 0) Scope / PR summary
-**PR title:** $PR_TITLE
-**PR author:** $PR_AUTHOR
-**Linked issues:** ${PR_LINKED_ISSUES:-None}
-
-**Summary:**
-$PR_BODY
-
----
-
-## 1) Diff Summary
-
-```
-$(head -n 40 "$PR_DIFF")
-```
-
----
-
-## 2) Risks / Assumptions
-(Add risks or assumptions here based on PR body or code changes)
-
----
-
-## 3) Validation / Acceptance Criteria
-(Add validation steps or acceptance criteria here)
-EOF
+if [[ ! -f "$PR_JSON" ]]; then
+  echo "PR JSON file not found: $PR_JSON"
+  exit 1
 fi
+
+if [[ ! -f "$PR_DIFF" ]]; then
+  echo "PR diff file not found: $PR_DIFF"
+  exit 1
+fi
+
+# Normalize to array for simpler processing.
+if jq -e 'type == "array"' "$PR_JSON" >/dev/null; then
+  PRS_JSON="$PR_JSON"
+else
+  PRS_JSON=$(mktemp)
+  jq -s '.' "$PR_JSON" > "$PRS_JSON"
+fi
+
+PR_COUNT=$(jq 'length' "$PRS_JSON")
+if [[ "$PR_COUNT" -eq 0 ]]; then
+  echo "No PR records found in $PR_JSON"
+  exit 1
+fi
+
+PR_NUMS_UNDERSCORE=$(jq -r '.[].number' "$PRS_JSON" | paste -sd '_' -)
+PR_NUMS_COMMA=$(jq -r '.[].number' "$PRS_JSON" | paste -sd ', ' -)
+DEV_SPEC_FILE="DEV_SPEC_PR_${PR_NUMS_UNDERSCORE}.md"
+
+{
+  if [[ "$PR_COUNT" -eq 1 ]]; then
+    echo "# Development Specification — PR #${PR_NUMS_COMMA}"
+  else
+    echo "# Development Specification — PRs ${PR_NUMS_COMMA}"
+  fi
+
+  echo
+  echo "## 0) Scope / PR summaries"
+
+  if [[ -n "$TRACKING_ISSUE_URL" ]]; then
+    echo "- **Tracking issue (created before dev spec):** $TRACKING_ISSUE_URL"
+    echo
+  fi
+
+  for i in $(seq 0 $((PR_COUNT - 1))); do
+    PR_NUM=$(jq -r ".[$i].number" "$PRS_JSON")
+    PR_TITLE=$(jq -r ".[$i].title" "$PRS_JSON")
+    PR_AUTHOR=$(jq -r ".[$i].author.login // \"unknown\"" "$PRS_JSON")
+    PR_URL=$(jq -r ".[$i].url // \"\"" "$PRS_JSON")
+    PR_BODY=$(jq -r ".[$i].body // \"\"" "$PRS_JSON")
+    PR_LINKED_ISSUES=$(jq -r ".[$i].linkedIssues[]?.number" "$PRS_JSON" | sed 's/^/#/' | paste -sd ', ' -)
+
+    echo "### PR #$PR_NUM"
+    echo "- **Title:** $PR_TITLE"
+    echo "- **Author:** $PR_AUTHOR"
+    if [[ -n "$PR_URL" ]]; then
+      echo "- **URL:** $PR_URL"
+    fi
+    echo "- **Linked issues:** ${PR_LINKED_ISSUES:-None}"
+    echo
+    echo "**Summary:**"
+    if [[ -n "$PR_BODY" ]]; then
+      echo "$PR_BODY"
+    else
+      echo "(No PR body provided.)"
+    fi
+    echo
+  done
+
+  echo "---"
+  echo "## 1) Diff Summary"
+  echo
+  echo '```diff'
+  head -n 200 "$PR_DIFF"
+  echo '```'
+  echo
+  echo "---"
+  echo "## 2) Risks / Assumptions"
+  echo "(Add risks or assumptions here based on PR bodies or code changes)"
+  echo
+  echo "---"
+  echo "## 3) Validation / Acceptance Criteria"
+  echo "(Add validation steps or acceptance criteria here)"
+} > "$DEV_SPEC_FILE"
+
+echo "$DEV_SPEC_FILE"

--- a/automation/scripts/dev_spec_from_pr.sh
+++ b/automation/scripts/dev_spec_from_pr.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./dev_spec_from_pr.sh <pr_json> <pr_diff>
+# Expects pr_json (from gh pr view --json ...) and pr_diff (from gh pr diff)
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <pr_json> <pr_diff>"
+  exit 1
+fi
+
+PR_JSON="$1"
+PR_DIFF="$2"
+
+# Check if PR_JSON is an array (multi-PR) or single object
+if jq -e 'type == "array"' "$PR_JSON" >/dev/null; then
+  PR_NUMS=$(jq -r '.[].number' "$PR_JSON" | paste -sd '_' -)
+  DEV_SPEC_FILE="DEV_SPEC_PR_${PR_NUMS}.md"
+  {
+    echo "# Development Specification — PRs $(jq -r '.[].number' "$PR_JSON" | paste -sd ', ' -)"
+    echo
+    echo "## 0) Scope / PR summaries"
+    PR_COUNT=$(jq 'length' "$PR_JSON")
+    for i in $(seq 0 $((PR_COUNT-1))); do
+      PR_TITLE=$(jq -r ".[$i].title" "$PR_JSON")
+      PR_AUTHOR=$(jq -r ".[$i].author.login" "$PR_JSON")
+      PR_LINKED_ISSUES=$(jq -r ".[$i].linkedIssues[]?.number" "$PR_JSON" | xargs -I{} echo "#{}" | paste -sd ", " -)
+      PR_BODY=$(jq -r ".[$i].body" "$PR_JSON")
+      PR_NUM=$(jq -r ".[$i].number" "$PR_JSON")
+      echo "### PR #$PR_NUM"
+      echo "- **Title:** $PR_TITLE"
+      echo "- **Author:** $PR_AUTHOR"
+      echo "- **Linked issues:** ${PR_LINKED_ISSUES:-None}"
+      echo
+      echo "**Summary:**"
+      echo "$PR_BODY"
+      echo
+    done
+    echo '---'
+    echo '## 1) Diff Summary'
+    echo '```
+'$(head -n 80 "$PR_DIFF")'
+```
+'
+    echo '---'
+    echo '## 2) Risks / Assumptions'
+    echo '(Add risks or assumptions here based on PR bodies or code changes)'
+    echo '---'
+    echo '## 3) Validation / Acceptance Criteria'
+    echo '(Add validation steps or acceptance criteria here)'
+  } > "$DEV_SPEC_FILE"
+else
+  PR_NUM=$(jq -r '.number' "$PR_JSON")
+  PR_TITLE=$(jq -r '.title' "$PR_JSON")
+  PR_BODY=$(jq -r '.body' "$PR_JSON")
+  PR_AUTHOR=$(jq -r '.author.login' "$PR_JSON")
+  PR_LINKED_ISSUES=$(jq -r '.linkedIssues[]?.number' "$PR_JSON" | xargs -I{} echo "#{}" | paste -sd ", " -)
+  cat > DEV_SPEC_PR_${PR_NUM}.md <<EOF
+# Development Specification — PR #${PR_NUM}
+
+## 0) Scope / PR summary
+**PR title:** $PR_TITLE
+**PR author:** $PR_AUTHOR
+**Linked issues:** ${PR_LINKED_ISSUES:-None}
+
+**Summary:**
+$PR_BODY
+
+---
+
+## 1) Diff Summary
+
+```
+$(head -n 40 "$PR_DIFF")
+```
+
+---
+
+## 2) Risks / Assumptions
+(Add risks or assumptions here based on PR body or code changes)
+
+---
+
+## 3) Validation / Acceptance Criteria
+(Add validation steps or acceptance criteria here)
+EOF
+fi

--- a/automation/scripts/dev_spec_from_pr.sh
+++ b/automation/scripts/dev_spec_from_pr.sh
@@ -44,8 +44,8 @@ if [[ "$PR_COUNT" -eq 0 ]]; then
   exit 1
 fi
 
-PR_NUMS_UNDERSCORE=$(jq -r '.[].number' "$PRS_JSON" | paste -sd '_' -)
-PR_NUMS_COMMA=$(jq -r '.[].number' "$PRS_JSON" | paste -sd ', ' -)
+PR_NUMS_UNDERSCORE=$(jq -r 'map(.number | tostring) | join("_")' "$PRS_JSON")
+PR_NUMS_COMMA=$(jq -r 'map(.number | tostring) | join(", ")' "$PRS_JSON")
 DEV_SPEC_FILE="DEV_SPEC_PR_${PR_NUMS_UNDERSCORE}.md"
 
 {
@@ -69,7 +69,7 @@ DEV_SPEC_FILE="DEV_SPEC_PR_${PR_NUMS_UNDERSCORE}.md"
     PR_AUTHOR=$(jq -r ".[$i].author.login // \"unknown\"" "$PRS_JSON")
     PR_URL=$(jq -r ".[$i].url // \"\"" "$PRS_JSON")
     PR_BODY=$(jq -r ".[$i].body // \"\"" "$PRS_JSON")
-    PR_LINKED_ISSUES=$(jq -r ".[$i].linkedIssues[]?.number" "$PRS_JSON" | sed 's/^/#/' | paste -sd ', ' -)
+    PR_LINKED_ISSUES=$(jq -r ".[$i].linkedIssues // [] | map(.number | tostring | \"#\" + .) | join(\", \")" "$PRS_JSON")
 
     echo "### PR #$PR_NUM"
     echo "- **Title:** $PR_TITLE"

--- a/automation/scripts/publish_dev_spec_from_pr.sh
+++ b/automation/scripts/publish_dev_spec_from_pr.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Usage: ./publish_dev_spec_from_pr.sh <repo> <comma-separated-pr-numbers> [issue-repo]
-# Example: ./publish_dev_spec_from_pr.sh KesterTan/GradienceV2 12,15,18 Gradient/GradientV1
+# Example: ./publish_dev_spec_from_pr.sh KesterTan/GradienceV2 12,15,18
 
 if [[ $# -lt 2 ]]; then
   echo "Usage: $0 <repo> <comma-separated-pr-numbers> [issue-repo]"
@@ -11,8 +11,10 @@ fi
 
 REPO="$1"
 PR_NUMBERS_RAW="$2"
-ISSUE_REPO="${3:-Gradient/GradientV1}"
+ISSUE_REPO="${3:-$REPO}"
 IFS=',' read -ra PRS <<< "$PR_NUMBERS_RAW"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GENERATOR_SCRIPT="$SCRIPT_DIR/dev_spec_from_pr.sh"
 
 command -v gh >/dev/null 2>&1 || { echo "gh is required"; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "jq is required"; exit 1; }
@@ -51,7 +53,7 @@ TRACKING_ISSUE_URL=$(gh issue create -R "$ISSUE_REPO" --title "$ISSUE_TITLE" --b
 echo "Created tracking issue: $TRACKING_ISSUE_URL"
 
 # Generate dev spec markdown (includes tracking issue reference)
-DEV_SPEC_FILE=$(bash automation/scripts/dev_spec_from_pr.sh "$TMP_DIR/prs.json" "$TMP_DIR/prs.diff" "$TRACKING_ISSUE_URL")
+DEV_SPEC_FILE=$(bash "$GENERATOR_SCRIPT" "$TMP_DIR/prs.json" "$TMP_DIR/prs.diff" "$TRACKING_ISSUE_URL")
 
 # Create dev-spec branch, commit, and push
 NORMALIZED_PRS=$(jq -r '.[].number' "$TMP_DIR/prs.json" | paste -sd '-' -)
@@ -62,4 +64,26 @@ git commit -m "dev spec for PR(s) $PR_NUMBERS_RAW"
 git push origin $BRANCH
 
 # Open PR for dev spec
-gh pr create -R "$REPO" --base main --head "$BRANCH" --title "Dev spec for PR(s) $PR_NUMBERS_RAW" --body "This PR adds a development specification for PR(s) $PR_NUMBERS_RAW.\n\nTracking issue: $TRACKING_ISSUE_URL"
+PR_BODY_FILE="$TMP_DIR/dev_spec_pr_body.md"
+cat > "$PR_BODY_FILE" <<EOF
+## What changed
+- Added a generated development specification draft for PR(s): $PR_NUMBERS_RAW.
+- Included tracking issue reference for auditability.
+
+## Backend changes
+- Added/updated automation scripts for PR analysis and dev spec generation.
+
+## Frontend changes
+- None.
+
+## Test changes
+- Shell syntax validated for updated scripts.
+
+## Risks / follow-ups
+- Validate generated draft content before publishing.
+- Complete and verify the Risks / Assumptions and Validation / Acceptance Criteria sections.
+
+Tracking issue: $TRACKING_ISSUE_URL
+EOF
+
+gh pr create -R "$REPO" --base main --head "$BRANCH" --title "Dev spec for PR(s) $PR_NUMBERS_RAW" --body-file "$PR_BODY_FILE"

--- a/automation/scripts/publish_dev_spec_from_pr.sh
+++ b/automation/scripts/publish_dev_spec_from_pr.sh
@@ -1,38 +1,65 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./publish_dev_spec_from_pr.sh <repo> <comma-separated-pr-numbers>
-# Example: ./publish_dev_spec_from_pr.sh KesterTan/GradienceV2 12,15,18
+# Usage: ./publish_dev_spec_from_pr.sh <repo> <comma-separated-pr-numbers> [issue-repo]
+# Example: ./publish_dev_spec_from_pr.sh KesterTan/GradienceV2 12,15,18 Gradient/GradientV1
 
 if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <repo> <comma-separated-pr-numbers>"
+  echo "Usage: $0 <repo> <comma-separated-pr-numbers> [issue-repo]"
   exit 1
 fi
 
 REPO="$1"
 PR_NUMBERS_RAW="$2"
+ISSUE_REPO="${3:-Gradient/GradientV1}"
 IFS=',' read -ra PRS <<< "$PR_NUMBERS_RAW"
 
+command -v gh >/dev/null 2>&1 || { echo "gh is required"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required"; exit 1; }
+command -v git >/dev/null 2>&1 || { echo "git is required"; exit 1; }
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
 # Fetch PR details and diffs
-> prs.json
-> prs.diff
+> "$TMP_DIR/prs.diff"
+> "$TMP_DIR/pr_urls.txt"
+
 for PR_NUM in "${PRS[@]}"; do
   PR_NUM_TRIM=$(echo "$PR_NUM" | xargs)
-  gh pr view "$PR_NUM_TRIM" --json title,body,number,headRefName,baseRefName,author,files,commits,additions,deletions,changedFiles,labels,assignees,reviewRequests,linkedIssues >> prs.json
-  echo -e "\n\n# Diff for PR $PR_NUM_TRIM\n" >> prs.diff
-  gh pr diff "$PR_NUM_TRIM" >> prs.diff
+  gh pr view "$PR_NUM_TRIM" -R "$REPO" --json title,body,number,url,headRefName,baseRefName,author,files,commits,additions,deletions,changedFiles,labels,assignees,reviewRequests,linkedIssues > "$TMP_DIR/pr_${PR_NUM_TRIM}.json"
+  jq -r '.url' "$TMP_DIR/pr_${PR_NUM_TRIM}.json" >> "$TMP_DIR/pr_urls.txt"
+  echo -e "\n\n# Diff for PR $PR_NUM_TRIM\n" >> "$TMP_DIR/prs.diff"
+  gh pr diff "$PR_NUM_TRIM" -R "$REPO" >> "$TMP_DIR/prs.diff"
 done
 
-# Generate dev spec markdown
-bash automation/scripts/dev_spec_from_pr.sh prs.json prs.diff
+# Build a valid JSON array of PR objects
+jq -s '.' "$TMP_DIR"/pr_*.json > "$TMP_DIR/prs.json"
+
+# Create tracking issue BEFORE generating dev spec
+ISSUE_TITLE="Dev spec request for PR(s) $PR_NUMBERS_RAW from $REPO"
+ISSUE_BODY=$(cat <<EOF
+Create and publish a development specification for the following PR(s) in $REPO:
+
+$(sed 's/^/- /' "$TMP_DIR/pr_urls.txt")
+
+This tracking issue was created automatically before dev spec generation.
+EOF
+)
+
+TRACKING_ISSUE_URL=$(gh issue create -R "$ISSUE_REPO" --title "$ISSUE_TITLE" --body "$ISSUE_BODY")
+echo "Created tracking issue: $TRACKING_ISSUE_URL"
+
+# Generate dev spec markdown (includes tracking issue reference)
+DEV_SPEC_FILE=$(bash automation/scripts/dev_spec_from_pr.sh "$TMP_DIR/prs.json" "$TMP_DIR/prs.diff" "$TRACKING_ISSUE_URL")
 
 # Create dev-spec branch, commit, and push
-BRANCH=dev-spec/pr-$(echo "$PR_NUMBERS_RAW" | tr ',' '-')
-DEV_SPEC_FILE=DEV_SPEC_PR_$(echo "$PR_NUMBERS_RAW" | tr ',' '_').md
+NORMALIZED_PRS=$(jq -r '.[].number' "$TMP_DIR/prs.json" | paste -sd '-' -)
+BRANCH="dev-spec/pr-${NORMALIZED_PRS}"
 git checkout -b $BRANCH
-git add $DEV_SPEC_FILE
+git add "$DEV_SPEC_FILE"
 git commit -m "dev spec for PR(s) $PR_NUMBERS_RAW"
 git push origin $BRANCH
 
 # Open PR for dev spec
-gh pr create --base main --head $BRANCH --title "Dev spec for PR(s) $PR_NUMBERS_RAW" --body "This PR adds a development specification for PR(s) $PR_NUMBERS_RAW."
+gh pr create -R "$REPO" --base main --head "$BRANCH" --title "Dev spec for PR(s) $PR_NUMBERS_RAW" --body "This PR adds a development specification for PR(s) $PR_NUMBERS_RAW.\n\nTracking issue: $TRACKING_ISSUE_URL"

--- a/automation/scripts/publish_dev_spec_from_pr.sh
+++ b/automation/scripts/publish_dev_spec_from_pr.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./publish_dev_spec_from_pr.sh <repo> <comma-separated-pr-numbers>
+# Example: ./publish_dev_spec_from_pr.sh KesterTan/GradienceV2 12,15,18
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <repo> <comma-separated-pr-numbers>"
+  exit 1
+fi
+
+REPO="$1"
+PR_NUMBERS_RAW="$2"
+IFS=',' read -ra PRS <<< "$PR_NUMBERS_RAW"
+
+# Fetch PR details and diffs
+> prs.json
+> prs.diff
+for PR_NUM in "${PRS[@]}"; do
+  PR_NUM_TRIM=$(echo "$PR_NUM" | xargs)
+  gh pr view "$PR_NUM_TRIM" --json title,body,number,headRefName,baseRefName,author,files,commits,additions,deletions,changedFiles,labels,assignees,reviewRequests,linkedIssues >> prs.json
+  echo -e "\n\n# Diff for PR $PR_NUM_TRIM\n" >> prs.diff
+  gh pr diff "$PR_NUM_TRIM" >> prs.diff
+done
+
+# Generate dev spec markdown
+bash automation/scripts/dev_spec_from_pr.sh prs.json prs.diff
+
+# Create dev-spec branch, commit, and push
+BRANCH=dev-spec/pr-$(echo "$PR_NUMBERS_RAW" | tr ',' '-')
+DEV_SPEC_FILE=DEV_SPEC_PR_$(echo "$PR_NUMBERS_RAW" | tr ',' '_').md
+git checkout -b $BRANCH
+git add $DEV_SPEC_FILE
+git commit -m "dev spec for PR(s) $PR_NUMBERS_RAW"
+git push origin $BRANCH
+
+# Open PR for dev spec
+gh pr create --base main --head $BRANCH --title "Dev spec for PR(s) $PR_NUMBERS_RAW" --body "This PR adds a development specification for PR(s) $PR_NUMBERS_RAW."


### PR DESCRIPTION
## Summary
- Adds a new Claude Code skill (`dev-spec-publisher`) for generating dev specs from one or more PRs
- Adds `dev_spec_from_pr.sh`: generates a dev spec markdown from PR JSON + diff (supports single and multi-PR)
- Adds `publish_dev_spec_from_pr.sh`: orchestrates fetching PR data, generating the spec, creating a branch, and opening a PR

## Linked Issue
- No linked issue (automation/tooling addition)

## Changes
### Backend
- None

### Frontend
- None

### Tests
- None (automation scripts, manual validation via invocation)

## Risks / Assumptions
- Scripts rely on `gh` CLI and `jq` being available in the environment
- Multi-PR JSON aggregation assumes `gh pr view` outputs one object per call (appended, not a JSON array); the script handles type detection at runtime

## Validation
- [ ] Tests run
- [ ] Manual verification completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated generation and publishing of development-spec drafts from one or more GitHub pull requests, including per-PR summaries, combined diffs, linked issues, risks/assumptions, and validation/acceptance templates.
  * Creates a tracking issue, opens a new branch, and files a pull request with the generated dev-spec; workflow can be manually triggered with repo and PR inputs.

* **Documentation**
  * Added user-facing guide describing the slash-command style interface and end-to-end workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->