### PR TITLE
resolved issues mentioned in issue raised from #85

### DIFF
--- a/app/api/courses/[courseId]/assignments/[assignmentId]/submit/route.ts
+++ b/app/api/courses/[courseId]/assignments/[assignmentId]/submit/route.ts
@@ -47,9 +47,14 @@ export async function POST(
       )
     }
 
-    // Confirm assignment belongs to this course and check deadline
+    // Confirm assignment belongs to this course and check deadline.
+    // Honor `lateUntil` so a configured late window actually accepts submissions.
     const assignmentRows = await db
-      .select({ id: assignments.id, dueAt: assignments.dueAt })
+      .select({
+        id: assignments.id,
+        dueAt: assignments.dueAt,
+        lateUntil: assignments.lateUntil,
+      })
       .from(assignments)
       .where(and(eq(assignments.id, parsedAssignmentId), eq(assignments.courseId, parsedCourseId)))
       .limit(1)
@@ -58,9 +63,20 @@ export async function POST(
       return NextResponse.json({ error: "Assignment not found" }, { status: 404 })
     }
 
-    if (new Date() > new Date(assignmentRows[0].dueAt)) {
-      return NextResponse.json({ error: "The submission deadline has passed" }, { status: 403 })
+    const now = new Date()
+    const dueAt = new Date(assignmentRows[0].dueAt)
+    const lateUntil = assignmentRows[0].lateUntil ? new Date(assignmentRows[0].lateUntil) : null
+    const isPastDue = now > dueAt
+    const inLateWindow = isPastDue && lateUntil !== null && now <= lateUntil
+
+    if (isPastDue && !inLateWindow) {
+      return NextResponse.json(
+        { error: lateUntil ? "The late submission deadline has passed" : "The submission deadline has passed" },
+        { status: 403 },
+      )
     }
+
+    const submissionStatus = isPastDue ? "late" : "submitted"
 
     // Parse file from form data
     const formData = await req.formData()
@@ -107,7 +123,7 @@ export async function POST(
         assignmentId: parsedAssignmentId,
         studentMembershipId: membership.id,
         attemptNumber: nextAttempt,
-        status: "submitted",
+        status: submissionStatus,
         fileUrl,
       })
       .returning({ id: submissions.id })

--- a/app/courses/[courseId]/assessments/[assignmentId]/edit/_components/edit-assignment-form.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/edit/_components/edit-assignment-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useActionState, useMemo, useState } from "react"
+import { useActionState, useEffect, useMemo, useRef, useState } from "react"
 import { updateAssignmentAction } from "../../../actions"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -52,6 +52,28 @@ export function EditAssignmentForm(props: {
   const [enableLateDeadline, setEnableLateDeadline] = useState(
     state.values?.enableLateDeadline === "on" ? true : Boolean(initialValues.lateUntilDate)
   )
+
+  // Keep checkbox + conditional inputs in sync with the server echo after
+  // every submit. This forces local state to match whatever was just sent,
+  // so the checkbox and the error/inputs never disagree on re-render.
+  useEffect(() => {
+    if (!state.values) return
+    setEnableLateDeadline(state.values.enableLateDeadline === "on")
+    setAllowResubmissions(state.values.allowResubmissions === "on")
+  }, [state])
+
+  // React 19's <form action={...}> auto-resets the DOM form after every
+  // action return. For controlled checkboxes, if the React state didn't
+  // change between renders, React bails out of re-applying the `checked`
+  // prop — leaving the DOM checkbox stuck on its post-reset value
+  // (unchecked) while local state still says true. Imperatively sync the
+  // DOM after every render so the DOM and the React state always agree.
+  const enableLateRef = useRef<HTMLInputElement>(null)
+  const allowResubRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (enableLateRef.current) enableLateRef.current.checked = enableLateDeadline
+    if (allowResubRef.current) allowResubRef.current.checked = allowResubmissions
+  })
 
   const dateError = useMemo(() => state.errors?.endDate?.[0], [state.errors?.endDate])
   const values = state.values ?? {}
@@ -149,6 +171,7 @@ export function EditAssignmentForm(props: {
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <input
+            ref={enableLateRef}
             id="enableLateDeadline"
             name="enableLateDeadline"
             type="checkbox"
@@ -194,6 +217,7 @@ export function EditAssignmentForm(props: {
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <input
+            ref={allowResubRef}
             id="allowResubmissions"
             name="allowResubmissions"
             type="checkbox"

--- a/app/courses/[courseId]/assessments/[assignmentId]/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/page.tsx
@@ -73,6 +73,11 @@ export default async function AssessmentPage({
             <p className="mt-1 text-sm text-muted-foreground">
               Due {format(new Date(assessment.dueAt), "MMM d, yyyy h:mm a")}
             </p>
+            {assessment.lateUntil && (
+              <p className="mt-1 text-sm text-amber-600">
+                Late submissions accepted until {format(new Date(assessment.lateUntil), "MMM d, yyyy h:mm a")}
+              </p>
+            )}
           </div>
           <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:justify-end">
             <Button asChild className="w-full sm:w-auto" variant="outline">

--- a/app/courses/[courseId]/assessments/_components/create-assignment-form.tsx
+++ b/app/courses/[courseId]/assessments/_components/create-assignment-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useActionState, useMemo, useState } from "react"
+import { useActionState, useEffect, useMemo, useRef, useState } from "react"
 import { createAssignmentAction } from "../actions"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -29,6 +29,7 @@ type AssignmentFormState = {
     startTime: string
     endDate: string
     endTime: string
+    enableLateDeadline: string
     lateUntilDate: string
     lateUntilTime: string
     allowResubmissions: string
@@ -46,6 +47,28 @@ export function CreateAssignmentForm({ courseId }: { courseId: number }) {
   const [enableLateDeadline, setEnableLateDeadline] = useState(
     state.values?.enableLateDeadline === "on"
   )
+
+  // Keep checkbox + conditional inputs in sync with the server echo after
+  // every submit. This forces local state to match whatever was just sent,
+  // so the checkbox and the error/inputs never disagree on re-render.
+  useEffect(() => {
+    if (!state.values) return
+    setEnableLateDeadline(state.values.enableLateDeadline === "on")
+    setAllowResubmissions(state.values.allowResubmissions === "on")
+  }, [state])
+
+  // React 19's <form action={...}> auto-resets the DOM form after every
+  // action return. For controlled checkboxes, if the React state didn't
+  // change between renders, React bails out of re-applying the `checked`
+  // prop — leaving the DOM checkbox stuck on its post-reset value
+  // (unchecked) while local state still says true. Imperatively sync the
+  // DOM after every render so the DOM and the React state always agree.
+  const enableLateRef = useRef<HTMLInputElement>(null)
+  const allowResubRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (enableLateRef.current) enableLateRef.current.checked = enableLateDeadline
+    if (allowResubRef.current) allowResubRef.current.checked = allowResubmissions
+  })
 
   const dateError = useMemo(() => state.errors?.endDate?.[0], [state.errors?.endDate])
 
@@ -141,6 +164,7 @@ export function CreateAssignmentForm({ courseId }: { courseId: number }) {
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <input
+            ref={enableLateRef}
             id="enableLateDeadline"
             name="enableLateDeadline"
             type="checkbox"
@@ -186,6 +210,7 @@ export function CreateAssignmentForm({ courseId }: { courseId: number }) {
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <input
+            ref={allowResubRef}
             id="allowResubmissions"
             name="allowResubmissions"
             type="checkbox"

--- a/app/courses/[courseId]/assessments/actions.ts
+++ b/app/courses/[courseId]/assessments/actions.ts
@@ -330,21 +330,20 @@ export async function createAssignmentAction(
     if (!values.lateUntilDate) {
       return { errors: { lateUntilDate: ["Late deadline date is required when late deadline is enabled."] }, values }
     }
+    // Any rule violation collapses to the same, always-accurate message.
+    // Rules a valid late deadline must satisfy:
+    //   1. The assignment must have an explicit end date (otherwise there is
+    //      no regular deadline for the late window to extend past).
+    //   2. The late deadline must be strictly after the assignment's end
+    //      date/time (the late window is a grace period past the regular due).
+    //   3. The late deadline must be on or before the course end date.
+    if (!parsed.data.endDate) {
+      return { errors: { lateUntilDate: ["Invalid late deadline date"] }, values }
+    }
     lateUntil = isoFromDateTime(values.lateUntilDate, values.lateUntilTime, true)
     const lateUntilMs = new Date(lateUntil).getTime()
-    if (lateUntilMs <= dueAtMs) {
-      const sameDayTimeConflict = Boolean(values.lateUntilDate === parsed.data.endDate && values.lateUntilTime?.trim() && parsed.data.endTime?.trim())
-      if (sameDayTimeConflict) {
-        return { errors: { lateUntilTime: ["Late deadline time must be after the normal deadline time when on the same date."] }, values }
-      }
-      return { errors: { lateUntilDate: ["Late deadline must be after the normal deadline."] }, values }
-    }
-    if (lateUntilMs < courseStartAt) {
-      return { errors: { lateUntilDate: ["Late deadline must be on or after the course start date."] }, values }
-    }
-    if (lateUntilMs > courseEndAt) {
-      const courseEndFormatted = new Date(courseEndAt).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })
-      return { errors: { lateUntilDate: [`Late deadline must be on or before ${courseEndFormatted}.`] }, values }
+    if (lateUntilMs <= dueAtMs || lateUntilMs > courseEndAt) {
+      return { errors: { lateUntilDate: ["Invalid late deadline date"] }, values }
     }
   }
 
@@ -487,21 +486,20 @@ export async function updateAssignmentAction(
     if (!values.lateUntilDate) {
       return { errors: { lateUntilDate: ["Late deadline date is required when late deadline is enabled."] }, values }
     }
+    // Any rule violation collapses to the same, always-accurate message.
+    // Rules a valid late deadline must satisfy:
+    //   1. The assignment must have an explicit end date (otherwise there is
+    //      no regular deadline for the late window to extend past).
+    //   2. The late deadline must be strictly after the assignment's end
+    //      date/time (the late window is a grace period past the regular due).
+    //   3. The late deadline must be on or before the course end date.
+    if (!parsed.data.endDate) {
+      return { errors: { lateUntilDate: ["Invalid late deadline date"] }, values }
+    }
     lateUntil = isoFromDateTime(values.lateUntilDate, values.lateUntilTime, true)
     const lateUntilMs = new Date(lateUntil).getTime()
-    if (lateUntilMs <= dueAtMs) {
-      const sameDayTimeConflict = Boolean(values.lateUntilDate === parsed.data.endDate && values.lateUntilTime?.trim() && parsed.data.endTime?.trim())
-      if (sameDayTimeConflict) {
-        return { errors: { lateUntilTime: ["Late deadline time must be after the normal deadline time when on the same date."] }, values }
-      }
-      return { errors: { lateUntilDate: ["Late deadline must be after the normal deadline."] }, values }
-    }
-    if (lateUntilMs < courseStartAt) {
-      return { errors: { lateUntilDate: ["Late deadline must be on or after the course start date."] }, values }
-    }
-    if (lateUntilMs > courseEndAt) {
-      const courseEndFormatted = new Date(courseEndAt).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })
-      return { errors: { lateUntilDate: [`Late deadline must be on or before ${courseEndFormatted}.`] }, values }
+    if (lateUntilMs <= dueAtMs || lateUntilMs > courseEndAt) {
+      return { errors: { lateUntilDate: ["Invalid late deadline date"] }, values }
     }
   }
 

--- a/components/assessment-submission-panel.tsx
+++ b/components/assessment-submission-panel.tsx
@@ -180,7 +180,7 @@ export function AssessmentSubmissionPanel({
                   <Calendar className="size-3.5" />
                   Due {format(dueDate, "MMM d, yyyy 'at' h:mm a")}
                 </p>
-                {!isInstructor && lateDate && (
+                {lateDate && (
                   <p className="mt-0.5 flex items-center gap-1 text-sm text-amber-600">
                     <Calendar className="size-3.5" />
                     Late submissions accepted until {format(lateDate, "MMM d, yyyy 'at' h:mm a")}

--- a/tests/assignments/create-assignment-action.jest.test.ts
+++ b/tests/assignments/create-assignment-action.jest.test.ts
@@ -90,10 +90,10 @@ beforeEach(() => {
   mockUpdate.mockReturnValue({ set: mockUpdateSet })
 })
 
-test("createAssignmentAction returns lateUntilDate error when late deadline date/time is not after due date/time", async () => {
+test("createAssignmentAction returns Invalid late deadline date when late deadline is not after due date/time", async () => {
   // function: createAssignmentAction
-  // input: due=2026-03-10 17:00, late=2026-03-09 16:00
-  // expected output: errors.lateUntilDate[0] = "Late deadline must be after the normal deadline."
+  // input: due=2026-03-10 17:00, late=2026-03-09 16:00 (before due)
+  // expected output: errors.lateUntilDate[0] = "Invalid late deadline date"
   selectQueue.push(
     [{ id: 999 }],
     [{ startDate: "2026-03-01", endDate: "2026-03-31" }],
@@ -113,16 +113,16 @@ test("createAssignmentAction returns lateUntilDate error when late deadline date
 
   const state = await createAssignmentAction({}, formData)
 
-  expect(state.errors?.lateUntilDate?.[0]).toBe("Late deadline must be after the normal deadline.")
+  expect(state.errors?.lateUntilDate?.[0]).toBe("Invalid late deadline date")
   expect(mockInsert).not.toHaveBeenCalled()
   expect(mockRevalidatePath).not.toHaveBeenCalled()
   expect(mockRedirect).not.toHaveBeenCalled()
 })
 
-test("createAssignmentAction returns lateUntilTime error for same-day late deadline time conflict", async () => {
+test("createAssignmentAction returns Invalid late deadline date for same-day late time before due", async () => {
   // function: createAssignmentAction
-  // input: due=2026-03-10 17:00, late=2026-03-10 16:00 (same day)
-  // expected output: errors.lateUntilTime[0] = same-day late-time validation message
+  // input: due=2026-03-10 17:00, late=2026-03-10 16:00 (same day, before due time)
+  // expected output: errors.lateUntilDate[0] = "Invalid late deadline date"
   selectQueue.push(
     [{ id: 999 }],
     [{ startDate: "2026-03-01", endDate: "2026-03-31" }],
@@ -142,9 +142,7 @@ test("createAssignmentAction returns lateUntilTime error for same-day late deadl
 
   const state = await createAssignmentAction({}, formData)
 
-  expect(state.errors?.lateUntilTime?.[0]).toBe(
-    "Late deadline time must be after the normal deadline time when on the same date.",
-  )
+  expect(state.errors?.lateUntilDate?.[0]).toBe("Invalid late deadline date")
   expect(mockInsert).not.toHaveBeenCalled()
 })
 
@@ -369,7 +367,7 @@ test("createAssignmentAction prioritizes due-vs-late ordering when late date is 
     lateUntilDate: "2026-03-01",
   })
   const state = await createAssignmentAction({}, formData)
-  expect(state.errors?.lateUntilDate?.[0]).toBe("Late deadline must be after the normal deadline.")
+  expect(state.errors?.lateUntilDate?.[0]).toBe("Invalid late deadline date")
 })
 
 test("createAssignmentAction enforces late deadline not after course end", async () => {
@@ -383,7 +381,7 @@ test("createAssignmentAction enforces late deadline not after course end", async
     lateUntilDate: "2026-03-30",
   })
   const state = await createAssignmentAction({}, formData)
-  expect(state.errors?.lateUntilDate?.[0]).toContain("Late deadline must be on or before")
+  expect(state.errors?.lateUntilDate?.[0]).toBe("Invalid late deadline date")
 })
 
 test("updateAssignmentAction validates title required", async () => {
@@ -511,7 +509,7 @@ test("updateAssignmentAction returns range-ordering error when derived start is 
   expect(state.errors?.endDate?.[0]).toBe("End date/time must be on or after start date/time")
 })
 
-test("updateAssignmentAction returns same-day late deadline time conflict", async () => {
+test("updateAssignmentAction returns Invalid late deadline date for same-day late time before due", async () => {
   selectQueue.push(
     [{ id: 999 }],
     [{ id: 7, releaseAt: "2026-03-01T00:00:00.000Z", dueAt: "2026-03-10T23:59:59.999Z" }],
@@ -529,9 +527,7 @@ test("updateAssignmentAction returns same-day late deadline time conflict", asyn
     lateUntilTime: "16:00",
   })
   const state = await updateAssignmentAction({}, formData)
-  expect(state.errors?.lateUntilTime?.[0]).toBe(
-    "Late deadline time must be after the normal deadline time when on the same date.",
-  )
+  expect(state.errors?.lateUntilDate?.[0]).toBe("Invalid late deadline date")
 })
 
 test("updateAssignmentAction enforces late deadline not after course end", async () => {
@@ -550,10 +546,10 @@ test("updateAssignmentAction enforces late deadline not after course end", async
     lateUntilDate: "2026-03-30",
   })
   const state = await updateAssignmentAction({}, formData)
-  expect(state.errors?.lateUntilDate?.[0]).toContain("Late deadline must be on or before")
+  expect(state.errors?.lateUntilDate?.[0]).toBe("Invalid late deadline date")
 })
 
-test("updateAssignmentAction returns lateUntilDate error when late deadline is before due date on a different day", async () => {
+test("updateAssignmentAction returns Invalid late deadline date when late is before due on a different day", async () => {
   selectQueue.push(
     [{ id: 999 }],
     [{ id: 7, releaseAt: "2026-03-01T00:00:00.000Z", dueAt: "2026-03-10T23:59:59.999Z" }],
@@ -571,5 +567,5 @@ test("updateAssignmentAction returns lateUntilDate error when late deadline is b
     lateUntilTime: "12:00",
   })
   const state = await updateAssignmentAction({}, formData)
-  expect(state.errors?.lateUntilDate?.[0]).toBe("Late deadline must be after the normal deadline.")
+  expect(state.errors?.lateUntilDate?.[0]).toBe("Invalid late deadline date")
 })

--- a/tests/components/assessment-submission-panel.test.tsx
+++ b/tests/components/assessment-submission-panel.test.tsx
@@ -1017,14 +1017,14 @@ describe("Instructor restore past deadline", () => {
 // ── 9. Assignment header — late-window date display ──────────────────────────
 //
 // When lateUntil is set the component renders "Late submissions accepted until
-// [date]" in the assignment header card. This is a student-only message:
-// instructors don't see it even if lateUntil is provided.
+// [date]" in the assignment header card. The date is shown to everyone — both
+// students (so they know their grace window) and instructors (so they can
+// confirm the configured late deadline at a glance).
 
 describe("Assignment header — late-window date display", () => {
   it("shows the late-until date in the header for a student when lateUntil is set", () => {
     // The header should display the grace-period deadline so students know how
-    // long they have to submit a late version. The text is only present when
-    // lateUntil is non-null and the viewer is not an instructor.
+    // long they have to submit a late version.
     render(
       <AssessmentSubmissionPanel
         {...defaultProps}
@@ -1037,9 +1037,9 @@ describe("Assignment header — late-window date display", () => {
     ).toBeInTheDocument()
   })
 
-  it("does not show the late-until date in the header for an instructor", () => {
-    // The late-deadline reminder is student-facing. Instructors set these dates
-    // themselves, so surfacing them in the submission panel would be noise.
+  it("shows the late-until date in the header for an instructor when lateUntil is set", () => {
+    // Instructors should also see the configured late deadline so the promise
+    // they made at assignment-creation time is visible on the assignment page.
     render(
       <AssessmentSubmissionPanel
         {...defaultProps}
@@ -1049,8 +1049,8 @@ describe("Assignment header — late-window date display", () => {
     )
 
     expect(
-      screen.queryByText(/late submissions accepted until/i),
-    ).not.toBeInTheDocument()
+      screen.getByText(/late submissions accepted until/i),
+    ).toBeInTheDocument()
   })
 
   it("does not show the late-until date when lateUntil is null", () => {


### PR DESCRIPTION
## Linked issue
Closes #85

## Summary
Resolves the bugs reported in #85 around the late-deadline feature on the
assignment create/edit forms and the assignment detail page. The original
issue surfaced two complaints, but investigating those uncovered three more
related gaps — all are addressed in this PR.

## What changed

### Validation (server)
- `app/courses/[courseId]/assessments/actions.ts`
  - Replaced the misleading "Late deadline must be after the normal deadline"
    message with the simple, always-accurate **"Invalid late deadline date"**
    for every late-deadline rule violation (no end date set, late ≤ due,
    late > course end). Empty-input case still returns the explicit
    "Late deadline date is required when late deadline is enabled."
  - The valid-late-deadline rules are documented in code: there must be an
    explicit assignment end date, the late deadline must be strictly after
    the assignment's end date/time, and it must be on or before the course
    end date.

### Forms (client)
- `app/courses/[courseId]/assessments/_components/create-assignment-form.tsx`
- `app/courses/[courseId]/assessments/[assignmentId]/edit/_components/edit-assignment-form.tsx`
  - Added `enableLateDeadline` to the form state type (was missing on the
    create form — slipped past TS because `next.config.mjs` has
    `ignoreBuildErrors: true`).
  - Added a `useEffect` that re-syncs the local checkbox state to the server
    echo after every action return so the checkbox, the conditional inputs,
    and the error message can never disagree.
  - Added a ref-based imperative DOM sync for both `enableLateDeadline` and
    `allowResubmissions` checkboxes. Root cause for the previously sticky
    bug: React 19's `<form action={...}>` auto-resets the DOM after the
    action returns; if the controlled `checked` prop didn't change between
    renders, React bails out of re-applying it, leaving the DOM checkbox
    visually unchecked while the React state still says `true`. The ref
    sync writes the correct `.checked` value back to the DOM after every
    render, eliminating the drift.

### Late deadline visibility (UI)
- `app/courses/[courseId]/assessments/[assignmentId]/page.tsx`
  - The assignment header now shows
    "Late submissions accepted until …" beneath the regular due date
    whenever `lateUntil` is set, so the late window the instructor promised
    at creation time is always visible on the assignment page.
- `components/assessment-submission-panel.tsx`
  - Removed the `!isInstructor` guard on the in-panel late deadline line so
    instructors also see the configured late window.

### Submission enforcement (server)
- `app/api/courses/[courseId]/assignments/[assignmentId]/submit/route.ts`
  - This older student-submission endpoint was rejecting any submission past
    `dueAt`, completely ignoring `lateUntil`. It now reads `lateUntil`,
    accepts submissions inside the late window (status stamped `late`),
    and returns the appropriate "submission" vs. "late submission" deadline
    message when both deadlines have passed. Behavior now matches the newer
    `assessments/.../submit` route, so the late window is honored regardless
    of which submit endpoint a client posts to.

## Backend changes
- Validation messages collapsed and clarified in `actions.ts`
  (create + update assignment).
- `lateUntil` is now enforced in the older
  `/api/courses/[courseId]/assignments/[assignmentId]/submit` route.

## Frontend changes
- Two-way + imperative checkbox sync in `create-assignment-form` and
  `edit-assignment-form`.
- `enableLateDeadline` added to the create-form state type.
- Late-window line is shown to instructors in the submission panel.
- "Late submissions accepted until …" is shown in the assignment page
  header when `lateUntil` is set.

## Test changes
- `tests/assignments/create-assignment-action.jest.test.ts` — updated six
  assertions for the new "Invalid late deadline date" message and rerouted
  the same-day time-conflict tests to assert the error on `lateUntilDate`
  (since the codepath no longer routes through `lateUntilTime`).
- `tests/components/assessment-submission-panel.test.tsx` — flipped the
  prior "instructor doesn't see late date" expectation to assert the
  instructor *does* see the late deadline (the new product behavior), and
  updated the surrounding section comment.

## Testing
- `npx jest --config jest.config.ts --watchman=false` — **139 / 139 passing**
- `npx vitest run` — **140 / 140 passing**
- Manually verified in dev server:
  - Setting an invalid late deadline displays "Invalid late deadline date"
    next to the late deadline field, the **Enable late deadline** checkbox
    stays checked, and the date/time inputs stay visible alongside the
    error.
  - The late deadline appears in the assignment detail page header and in
    the submission panel for both students and instructors.
  - Submissions past `dueAt` but within `lateUntil` are accepted and
    stamped `late`; submissions past `lateUntil` are rejected with
    "The late submission deadline has passed".

## Risks / follow-ups
- The unused legacy components `components/pdf-upload-form.tsx` and
  `components/restore-button.tsx` still target the older
  `/assignments/.../submit` and `/assignments/.../submissions/[id]/restore`
  endpoints; they're not wired into any active page but are still on disk.
  Now that the older submit route enforces `lateUntil`, leaving them is
  safe, but a follow-up cleanup PR could delete them.
- `tests/components/assessment-submission-panel.test.tsx` is currently
  matched by neither Vitest nor Jest (filename doesn't fit either runner's
  glob: vitest only picks up `*.test.ts`, jest only picks up
  `*.jest.test.ts(x)`). The file compiles cleanly and was updated to match
  the new behavior, but for those tests to actually run on CI it should be
  renamed to `assessment-submission-panel.jest.test.tsx`. Not done in this
  PR to keep scope tight; flagging for a quick follow-up.
- `next.config.mjs` has `typescript.ignoreBuildErrors: true`, which is what
  let the missing `enableLateDeadline` field on the form state type slip
  through originally. Worth tightening as a separate hardening task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced support for assignment late submission windows with distinct deadlines separate from the regular due date.
  * Submissions are now marked as "late" when submitted after the due date but before the late deadline.
  * Added UI notices displaying when late submissions are accepted (visible to both students and instructors).

* **Bug Fixes**
  * Fixed checkbox state synchronization issues in assignment creation and editing forms.

* **Tests**
  * Updated test expectations for late deadline validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->