### PR TITLE
fixed the issue concerning issue 84

### DIFF
--- a/app/courses/actions.ts
+++ b/app/courses/actions.ts
@@ -15,6 +15,16 @@ export type CourseFormState = {
     courseId?: string[]
     _form?: string[]
   }
+  values?: {
+    title: string
+    startDate: string
+    endDate: string
+  }
+}
+
+function readFormValue(formData: FormData, key: string) {
+  const value = formData.get(key)
+  return typeof value === "string" ? value : ""
 }
 
 const emptyToUndefined = (value: unknown) => {
@@ -67,6 +77,15 @@ export async function createCourseAction(
 ): Promise<CourseFormState> {
   const grader = await requireGraderUser()
 
+  // Capture submitted values up-front so we can echo them back on any error.
+  // This preserves the user's input across a failed submission rather than
+  // forcing them to re-enter everything when only one field was invalid.
+  const values = {
+    title: readFormValue(formData, "title"),
+    startDate: readFormValue(formData, "startDate"),
+    endDate: readFormValue(formData, "endDate"),
+  }
+
   const parsed = createSchema.safeParse({
     title: formData.get("title"),
     startDate: formData.get("startDate"),
@@ -74,7 +93,7 @@ export async function createCourseAction(
   })
 
   if (!parsed.success) {
-    return { errors: parsed.error.flatten().fieldErrors }
+    return { errors: parsed.error.flatten().fieldErrors, values }
   }
 
   const { title, startDate, endDate } = parsed.data

--- a/components/create-course-form.tsx
+++ b/components/create-course-form.tsx
@@ -18,20 +18,39 @@ export function CreateCourseForm() {
     <form action={formAction} className="space-y-5 rounded-xl border bg-white p-6 shadow-sm">
       <div className="space-y-2">
         <Label htmlFor="title">Course title</Label>
-        <Input id="title" name="title" required placeholder="e.g. Intro to Databases" aria-invalid={!!state.errors?.title} />
+        <Input
+          id="title"
+          name="title"
+          required
+          placeholder="e.g. Intro to Databases"
+          defaultValue={state.values?.title ?? ""}
+          aria-invalid={!!state.errors?.title}
+        />
         {state.errors?.title?.[0] && <p className="text-sm text-destructive">{state.errors.title[0]}</p>}
       </div>
 
       <div className="grid gap-5 sm:grid-cols-2">
         <div className="space-y-2">
           <Label htmlFor="startDate">Start date</Label>
-          <Input id="startDate" name="startDate" type="date" aria-invalid={!!state.errors?.startDate} />
+          <Input
+            id="startDate"
+            name="startDate"
+            type="date"
+            defaultValue={state.values?.startDate ?? ""}
+            aria-invalid={!!state.errors?.startDate}
+          />
           {state.errors?.startDate?.[0] && <p className="text-sm text-destructive">{state.errors.startDate[0]}</p>}
         </div>
 
         <div className="space-y-2">
           <Label htmlFor="endDate">End date</Label>
-          <Input id="endDate" name="endDate" type="date" aria-invalid={!!state.errors?.endDate} />
+          <Input
+            id="endDate"
+            name="endDate"
+            type="date"
+            defaultValue={state.values?.endDate ?? ""}
+            aria-invalid={!!state.errors?.endDate}
+          />
           {dateError && <p className="text-sm text-destructive">{dateError}</p>}
         </div>
       </div>

--- a/tests/app/courses/actions.test.ts
+++ b/tests/app/courses/actions.test.ts
@@ -45,6 +45,38 @@ describe("createCourseAction", () => {
     expect(mocks.transaction).not.toHaveBeenCalled()
   })
 
+  it("echoes submitted values back on validation failure so the form can preserve them", async () => {
+    const formData = new FormData()
+    formData.set("title", "CS101 - Intro")
+    formData.set("startDate", "2026-05-10")
+    formData.set("endDate", "2026-05-01")
+
+    const state = await createCourseAction({}, formData)
+
+    expect(state.errors?.endDate?.[0]).toBe("End date must be on or after start date")
+    expect(state.values).toEqual({
+      title: "CS101 - Intro",
+      startDate: "2026-05-10",
+      endDate: "2026-05-01",
+    })
+  })
+
+  it("echoes submitted values back when title is missing too", async () => {
+    const formData = new FormData()
+    formData.set("title", "")
+    formData.set("startDate", "2026-05-10")
+    formData.set("endDate", "2026-05-20")
+
+    const state = await createCourseAction({}, formData)
+
+    expect(state.errors?.title?.[0]).toBe("Course title is required")
+    expect(state.values).toEqual({
+      title: "",
+      startDate: "2026-05-10",
+      endDate: "2026-05-20",
+    })
+  })
+
   it("inserts a course and creator membership, then revalidates and redirects", async () => {
     const insert = vi.fn()
     const courseValues = vi.fn().mockReturnValue({


### PR DESCRIPTION
## Linked issue
Closes #84

## Summary
When creating a new course, entering an invalid date range (end date before
start date) correctly triggered the "End date must be on or after start date"
error, but the form **also wiped the course title and date inputs** — forcing
the user to retype valid fields they hadn't changed. This PR makes the form
preserve all submitted values across a failed submission so users only need
to correct the field that's actually invalid.

## Root cause
`createCourseAction` returned only `errors` on validation failure — it never
echoed back the submitted `values`. `CreateCourseForm`'s inputs had no
`defaultValue` referencing form state, so when React 19's
`<form action={...}>` automatically resets the DOM after the action returns,
every field reverted to empty.

## Backend changes
- `app/courses/actions.ts`
  - Extended `CourseFormState` with a `values` field carrying `title`,
    `startDate`, `endDate`.
  - `createCourseAction` now captures the submitted values up-front and
    echoes them back in the error response so the form can re-populate.

## Frontend changes
- `components/create-course-form.tsx`
  - Wired `defaultValue={state.values?.x ?? ""}` on the title, start-date,
    and end-date inputs. React updates each input's `defaultValue` on
    re-render, so when React 19's automatic `form.reset()` fires after the
    action returns, the form resets to the **submitted** values rather than
    to empty.

## Test changes
- `tests/app/courses/actions.test.ts` — added two regression tests:
  - On end-before-start failure, `state.values` carries `title`,
    `startDate`, `endDate` exactly as submitted.
  - On missing title, the other valid fields (`startDate`, `endDate`) are
    still preserved in `state.values`.

## Testing
- `npx vitest run` — **142 / 142 passing** (+2 new)
- `npx jest --config jest.config.ts --watchman=false` — **139 / 139 passing**
- Manually verified in the dev server: enter a course title + start date +
  end-before-start, submit → "End date must be on or after start date"
  appears under the End date field, and **the title, start date, and end
  date all remain populated**.

## Risks / follow-ups
- None. This change strictly adds optional state and `defaultValue` props;
  the success path and error semantics are unchanged.
- The same pattern is already used in the assignment create/edit forms, so
  the course form now matches that proven shape.