### PR TITLE
Email, password length sanitization + username in header fix

### DIFF
--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -19,11 +19,19 @@ export function AppHeader({ user }: { user: AuthenticatedUser }) {
   const isOnHome = currentPage === "home"
   const normalizedName = user.name?.trim().toLowerCase()
   const normalizedEmail = user.email?.trim().toLowerCase()
+  const usernameFromEmail = user.email
+    ?.split("@")[0]
+    ?.trim()
+    ?.replace(/[._-]+/g, " ")
+    ?.replace(/\s+/g, " ")
+    ?.trim()
   const isEmailLikeName =
     !!normalizedName &&
     !!normalizedEmail &&
     (normalizedName === normalizedEmail || normalizedName === `${normalizedEmail} account`)
-  const displayName = isEmailLikeName ? "Account" : (user.name ?? "Signed in user")
+  const displayName = isEmailLikeName
+    ? (usernameFromEmail ? usernameFromEmail : "Signed in user")
+    : (user.name ?? "Signed in user")
   const initials =
     displayName
       ?.split(" ")

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -17,8 +17,15 @@ export function AppHeader({ user }: { user: AuthenticatedUser }) {
 
   const canGoToGrading = gradingComplete[selectedStudentId]
   const isOnHome = currentPage === "home"
+  const normalizedName = user.name?.trim().toLowerCase()
+  const normalizedEmail = user.email?.trim().toLowerCase()
+  const isEmailLikeName =
+    !!normalizedName &&
+    !!normalizedEmail &&
+    (normalizedName === normalizedEmail || normalizedName === `${normalizedEmail} account`)
+  const displayName = isEmailLikeName ? "Account" : (user.name ?? "Signed in user")
   const initials =
-    user.name
+    displayName
       ?.split(" ")
       .map((part) => part[0])
       .join("")
@@ -110,12 +117,12 @@ export function AppHeader({ user }: { user: AuthenticatedUser }) {
 
       <div className="flex items-center gap-3">
         <div className="hidden text-right sm:block">
-          <p className="text-sm font-medium leading-none text-foreground">{user.name ?? "Signed in user"}</p>
+          <p className="text-sm font-medium leading-none text-foreground">{displayName}</p>
           {user.email && <p className="mt-1 text-xs text-muted-foreground">{user.email}</p>}
         </div>
 
         <Avatar>
-          {user.picture && <AvatarImage src={user.picture} alt={user.name ?? "User avatar"} />}
+          {user.picture && <AvatarImage src={user.picture} alt={displayName} />}
           <AvatarFallback>{initials}</AvatarFallback>
         </Avatar>
 

--- a/components/dashboard-header.tsx
+++ b/components/dashboard-header.tsx
@@ -30,6 +30,12 @@ export function DashboardHeader({
   const hasBreadcrumbs = !!breadcrumbs?.length
   const homeIsActive = breadcrumbs?.[0]?.current === true
   const homeHref = breadcrumbs?.[0]?.href ?? "/courses"
+  const normalizedName = user.name.trim().toLowerCase()
+  const normalizedEmail = user.email.trim().toLowerCase()
+  const isEmailLikeName =
+    normalizedName === normalizedEmail ||
+    normalizedName === `${normalizedEmail} account`
+  const displayName = isEmailLikeName ? "Account" : user.name
 
   return (
     <header className="border-b bg-white">
@@ -77,7 +83,7 @@ export function DashboardHeader({
             </Button>
           )}
           <div className="hidden text-right sm:block">
-            <p className="text-sm font-medium text-foreground">{user.name}</p>
+            <p className="text-sm font-medium text-foreground">{displayName}</p>
             <p className="text-xs text-muted-foreground">{user.email}</p>
           </div>
           <Button asChild size="sm" variant="outline">

--- a/components/dashboard-header.tsx
+++ b/components/dashboard-header.tsx
@@ -32,10 +32,16 @@ export function DashboardHeader({
   const homeHref = breadcrumbs?.[0]?.href ?? "/courses"
   const normalizedName = user.name.trim().toLowerCase()
   const normalizedEmail = user.email.trim().toLowerCase()
+  const usernameFromEmail = user.email
+    .split("@")[0]
+    .trim()
+    .replace(/[._-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
   const isEmailLikeName =
     normalizedName === normalizedEmail ||
     normalizedName === `${normalizedEmail} account`
-  const displayName = isEmailLikeName ? "Account" : user.name
+  const displayName = isEmailLikeName ? (usernameFromEmail || "Signed in user") : user.name
 
   return (
     <header className="border-b bg-white">


### PR DESCRIPTION
## Summary
This PR improves authentication/profile display behavior and hardens signup validation.

This resolves #73 #76 

## What changed

### 1) Header account display no longer duplicates email
- Fixed top-right account display so it does not show an email-like value twice.
- If a real display name exists, it is shown.
- If the name is email-like (or email-derived), the UI now shows a username-style fallback (derived from the email local-part) instead of showing `Account`.
- Applied consistently across both app header variants.

### 2) Better username fallback behavior
- If a username exists, it is used for display.
- If no username is available, a username is generated from the email local-part for display purposes.
- Generic `Account` fallback is avoided unless no meaningful identifier is available.

### 3) Auth input length sanitization
- Added/updated validation to enforce max length constraints for:
  - username
  - email
  - password
- Intended to prevent overlong values and reduce risk of malformed/abusive payloads at signup/auth boundaries.


<img width="456" height="118" alt="Screenshot 2026-05-03 at 4 13 06 AM" src="https://github.com/user-attachments/assets/c306911f-80fc-4dd9-b58f-7756c5cb0a8a" />
<img width="456" height="118" alt="Screenshot 2026-05-03 at 4 13 06 AM" src="https://github.com/user-attachments/assets/c306911f-80fc-4dd9-b58f-7756c5cb0a8a" />
<img width="303" height="82" alt="Screenshot 2026-05-03 at 4 31 32 AM" src="https://github.com/user-attachments/assets/e4044719-e62d-455d-b227-fd0921f5f8db" />
<img width="303" height="82" alt="Screenshot 2026-05-03 at 4 31 32 AM" src="https://github.com/user-attachments/assets/e4044719-e62d-455d-b227-fd0921f5f8db" />
<img width="390" height="541" alt="Screenshot 2026-05-03 at 4 59 49 AM" src="https://github.com/user-attachments/assets/43015993-28b6-451e-8bd0-c44baab39563" />
<img width="390" height="541" alt="Screenshot 2026-05-03 at 4 59 49 AM" src="https://github.com/user-attachments/assets/43015993-28b6-451e-8bd0-c44baab39563" />
<img width="397" height="542" alt="Screenshot 2026-05-03 at 5 00 39 AM" src="https://github.com/user-attachments/assets/b7df1f96-bc5d-4726-b827-6c4ce148ce6c" />
<img width="397" height="542" alt="Screenshot 2026-05-03 at 5 00 39 AM" src="https://github.com/user-attachments/assets/b7df1f96-bc5d-4726-b827-6c4ce148ce6c" />
<img width="373" height="449" alt="Screenshot 2026-05-03 at 5 03 26 AM" src="https://github.com/user-attachments/assets/8e9b4517-e1f1-4f30-ba8b-f9642add6307" />
<img width="373" height="449" alt="Screenshot 2026-05-03 at 5 03 26 AM" src="https://github.com/user-attachments/assets/8e9b4517-e1f1-4f30-ba8b-f9642add6307" />
<img width="396" height="573" alt="Screenshot 2026-05-03 at 5 11 22 AM" src="https://github.com/user-attachments/assets/38f3eee2-68c9-4d6e-955f-ddf99d7a3728" />
<img width="396" height="573" alt="Screenshot 2026-05-03 at 5 11 22 AM" src="https://github.com/user-attachments/assets/38f3eee2-68c9-4d6e-955f-ddf99d7a3728" />
<img width="256" height="78" alt="Screenshot 2026-05-03 at 5 37 16 AM" src="https://github.com/user-attachments/assets/e367face-e18f-405c-8501-545399dbe553" />
<img width="256" height="78" alt="Screenshot 2026-05-03 at 5 37 16 AM" src="https://github.com/user-attachments/assets/e367face-e18f-405c-8501-545399dbe553" />
<img width="283" height="70" alt="Screenshot 2026-05-03 at 5 37 31 AM" src="https://github.com/user-attachments/assets/c78c295e-55bc-4538-81db-8c6da364f235" />
<img width="283" height="70" alt="Screenshot 2026-05-03 at 5 37 31 AM" src="https://github.com/user-attachments/assets/c78c295e-55bc-4538-81db-8c6da364f235" />

## Why
- Improves profile UX clarity (no duplicate identity text in header).
- Makes account labeling more human-readable and stable.
- Adds defensive validation and security hardening for auth-related fields.

## Impact
- No breaking API/schema changes expected.
- UI-only behavior change for account label rendering.
- Validation now rejects overlong auth fields earlier.

## Validation performed
- Local build succeeds (`npm run build`).
- Manual verification of header behavior with email-like and normal profile names.
- Manual verification of length guard behavior for username/email/password edge cases.

## Follow-ups (optional)
- Add automated tests for header display fallback matrix.
- Add explicit auth validation tests for max-length rejection paths.
- Align Auth0 tenant-side rules and app-side validations to identical limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user display name handling in app and dashboard headers to consistently show normalized user names for better clarity across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->