### PR TITLE
Fix Head handler

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -6,4 +6,4 @@ async function handler(request: NextRequest) {
 	return auth0.middleware(request)
 }
 
-export { handler as GET, handler as POST }
+export { handler as GET, handler as POST, handler as HEAD }


### PR DESCRIPTION
## Summary
Fixes an Auth route method-handling gap causing `HEAD /api/auth/login` to return 500 in production while `GET` correctly returns a redirect.

Resolves #74

## Root cause
The catch-all Auth route exported `GET` and `POST` handlers only. `HEAD` requests were not explicitly handled, which led to incorrect runtime behavior on this endpoint.

## Change
Added an explicit `HEAD` handler export that reuses the same `handler` as `GET`/`POST`.

## Behavior after fix
- `HEAD /api/auth/login?...` now follows the same Auth0 middleware flow as `GET`
- Expected redirect behavior is preserved for clients that use `HEAD` (CDNs, crawlers, health checks)

## Why this is safe
No new logic was introduced. The change only maps an additional HTTP method (`HEAD`) to the existing, already-used route handler.

## Validation
- Type check / editor diagnostics: no errors in the updated route file
- Expected request parity: `HEAD` now handled consistently with `GET` for login start URL