### PR TITLE
Add Auth0 account-link confirmation flow

### DIFF
--- a/app/auth/account-link/page.tsx
+++ b/app/auth/account-link/page.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link"
+import { redirect } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { getAuth0ContinueUrl, linkAccountsFromActionToken, parseAccountLinkToken } from "@/lib/auth0-account-linking"
+
+async function continueWithoutLinkAction(formData: FormData) {
+  "use server"
+
+  const state = String(formData.get("state") ?? "").trim()
+  if (!state) {
+    redirect("/login?error=missing_state")
+  }
+
+  redirect(getAuth0ContinueUrl(state))
+}
+
+async function confirmLinkAndContinueAction(formData: FormData) {
+  "use server"
+
+  const state = String(formData.get("state") ?? "").trim()
+  const token = String(formData.get("account_link_token") ?? "").trim()
+
+  if (!state) {
+    redirect("/login?error=missing_state")
+  }
+
+  if (!token) {
+    redirect(`/auth/account-link?state=${encodeURIComponent(state)}&error=missing_token`)
+  }
+
+  try {
+    await linkAccountsFromActionToken(token)
+    redirect(getAuth0ContinueUrl(state))
+  } catch {
+    const destination = new URL("/auth/account-link", "http://localhost")
+    destination.searchParams.set("state", state)
+    destination.searchParams.set("account_link_token", token)
+    destination.searchParams.set("error", "link_failed")
+    redirect(destination.pathname + destination.search)
+  }
+}
+
+type SearchParams = Record<string, string | string[] | undefined>
+
+function firstValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function AccountLinkPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams> | SearchParams
+}) {
+  const resolvedParams = await Promise.resolve(searchParams)
+
+  const state = (firstValue(resolvedParams.state) ?? "").trim()
+  const token = (firstValue(resolvedParams.account_link_token) ?? "").trim()
+  const error = (firstValue(resolvedParams.error) ?? "").trim()
+
+  let currentEmail = ""
+  let candidateEmail = ""
+  let tokenInvalid = false
+
+  if (token) {
+    try {
+      const payload = parseAccountLinkToken(token)
+      currentEmail = payload.current_email ?? ""
+      candidateEmail = payload.candidate_email ?? ""
+    } catch {
+      tokenInvalid = true
+    }
+  }
+
+  const hasRequiredParams = Boolean(state) && Boolean(token) && !tokenInvalid
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-muted/30 p-6">
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle>Confirm account linking</CardTitle>
+          <CardDescription>
+            We found another sign-in method with the same email. Link both identities to use a single account.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error === "link_failed" && (
+            <p className="text-sm text-destructive">
+              We couldn&apos;t link the accounts automatically. You can continue login and retry later.
+            </p>
+          )}
+
+          {!state && (
+            <p className="text-sm text-destructive">Missing login state. Restart sign-in from the login page.</p>
+          )}
+
+          {tokenInvalid && (
+            <p className="text-sm text-destructive">Invalid or expired account linking token. Restart sign-in.</p>
+          )}
+
+          {hasRequiredParams && (
+            <div className="rounded-md border bg-background p-3 text-sm">
+              <p>
+                <span className="font-medium">Current sign-in:</span> {currentEmail || "Unknown"}
+              </p>
+              <p>
+                <span className="font-medium">Existing account:</span> {candidateEmail || "Unknown"}
+              </p>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            {hasRequiredParams ? (
+              <form action={confirmLinkAndContinueAction}>
+                <input type="hidden" name="state" value={state} />
+                <input type="hidden" name="account_link_token" value={token} />
+                <Button className="w-full" type="submit">
+                  Link and continue
+                </Button>
+              </form>
+            ) : null}
+
+            {state ? (
+              <form action={continueWithoutLinkAction}>
+                <input type="hidden" name="state" value={state} />
+                <Button className="w-full" type="submit" variant="outline">
+                  Continue without linking
+                </Button>
+              </form>
+            ) : (
+              <Button asChild className="w-full" variant="outline">
+                <Link href="/login">Back to login</Link>
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/lib/auth0-account-linking.ts
+++ b/lib/auth0-account-linking.ts
@@ -1,0 +1,214 @@
+import { createHmac, timingSafeEqual } from "node:crypto"
+
+type AccountLinkTokenPayload = {
+  current_user_id?: string
+  current_email?: string
+  candidate_user_id?: string
+  candidate_email?: string
+  exp?: number
+  iat?: number
+}
+
+type Auth0Identity = {
+  provider?: string
+  user_id?: string
+}
+
+type Auth0User = {
+  user_id: string
+  email?: string
+  email_verified?: boolean
+  identities?: Auth0Identity[]
+}
+
+function resolveAuth0Domain() {
+  const fromDomain = process.env.AUTH0_DOMAIN
+  if (fromDomain) {
+    return fromDomain
+  }
+
+  const issuer = process.env.AUTH0_ISSUER_BASE_URL
+  if (!issuer) {
+    throw new Error("Missing AUTH0_DOMAIN or AUTH0_ISSUER_BASE_URL")
+  }
+
+  const normalizedIssuer = issuer.startsWith("http") ? issuer : `https://${issuer}`
+  return new URL(normalizedIssuer).host
+}
+
+function getLinkTokenSecret() {
+  const secret = process.env.AUTH0_MGMT_CLIENT_SECRET
+  if (!secret) {
+    throw new Error("Missing AUTH0_MGMT_CLIENT_SECRET")
+  }
+  return secret
+}
+
+function base64urlDecode(input: string) {
+  return Buffer.from(input, "base64url").toString("utf8")
+}
+
+function verifyActionToken(token: string): AccountLinkTokenPayload {
+  const [headerSegment, payloadSegment, signatureSegment] = token.split(".")
+  if (!headerSegment || !payloadSegment || !signatureSegment) {
+    throw new Error("Invalid account link token")
+  }
+
+  const secret = getLinkTokenSecret()
+  const data = `${headerSegment}.${payloadSegment}`
+  const expectedSignature = createHmac("sha256", secret).update(data).digest("base64url")
+
+  const expectedBuffer = Buffer.from(expectedSignature)
+  const actualBuffer = Buffer.from(signatureSegment)
+  if (expectedBuffer.length !== actualBuffer.length || !timingSafeEqual(expectedBuffer, actualBuffer)) {
+    throw new Error("Account link token signature verification failed")
+  }
+
+  const payload = JSON.parse(base64urlDecode(payloadSegment)) as AccountLinkTokenPayload
+  const now = Math.floor(Date.now() / 1000)
+  if (typeof payload.exp === "number" && payload.exp < now) {
+    throw new Error("Account link token expired")
+  }
+
+  return payload
+}
+
+async function getManagementToken(domain: string) {
+  const clientId = process.env.AUTH0_MGMT_CLIENT_ID
+  const clientSecret = process.env.AUTH0_MGMT_CLIENT_SECRET
+
+  if (!clientId || !clientSecret) {
+    throw new Error("Missing AUTH0_MGMT_CLIENT_ID or AUTH0_MGMT_CLIENT_SECRET")
+  }
+
+  const response = await fetch(`https://${domain}/oauth/token`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "client_credentials",
+      client_id: clientId,
+      client_secret: clientSecret,
+      audience: `https://${domain}/api/v2/`,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error("Unable to get Auth0 Management API token")
+  }
+
+  const body = (await response.json()) as { access_token?: string }
+  if (!body.access_token) {
+    throw new Error("Auth0 Management API token missing access_token")
+  }
+
+  return body.access_token
+}
+
+async function getUserById(params: { domain: string; mgmtToken: string; userId: string }) {
+  const { domain, mgmtToken, userId } = params
+  const encodedUserId = encodeURIComponent(userId)
+
+  const response = await fetch(`https://${domain}/api/v2/users/${encodedUserId}`, {
+    method: "GET",
+    headers: {
+      authorization: `Bearer ${mgmtToken}`,
+      "content-type": "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Unable to load Auth0 user ${userId}`)
+  }
+
+  return (await response.json()) as Auth0User
+}
+
+function choosePrimaryUser(current: Auth0User, candidate: Auth0User) {
+  const currentProvider = current.identities?.[0]?.provider
+  const candidateProvider = candidate.identities?.[0]?.provider
+  if (currentProvider !== "auth0") return current
+  if (candidateProvider !== "auth0") return candidate
+  return current
+}
+
+async function linkIdentity(params: {
+  domain: string
+  mgmtToken: string
+  primaryUserId: string
+  secondaryProvider: string
+  secondaryUserId: string
+}) {
+  const { domain, mgmtToken, primaryUserId, secondaryProvider, secondaryUserId } = params
+  const encodedPrimary = encodeURIComponent(primaryUserId)
+
+  const response = await fetch(`https://${domain}/api/v2/users/${encodedPrimary}/identities`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${mgmtToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      provider: secondaryProvider,
+      user_id: secondaryUserId,
+    }),
+  })
+
+  if (response.ok || response.status === 409) {
+    return
+  }
+
+  throw new Error("Auth0 identity link request failed")
+}
+
+export function getAuth0ContinueUrl(state: string) {
+  const domain = resolveAuth0Domain()
+  const continueUrl = new URL(`https://${domain}/continue`)
+  continueUrl.searchParams.set("state", state)
+  return continueUrl.toString()
+}
+
+export function parseAccountLinkToken(token: string) {
+  return verifyActionToken(token)
+}
+
+export async function linkAccountsFromActionToken(token: string) {
+  const payload = verifyActionToken(token)
+  const currentUserId = payload.current_user_id
+  const candidateUserId = payload.candidate_user_id
+
+  if (!currentUserId || !candidateUserId || currentUserId === candidateUserId) {
+    throw new Error("Invalid account linking payload")
+  }
+
+  const domain = resolveAuth0Domain()
+  const mgmtToken = await getManagementToken(domain)
+
+  const current = await getUserById({ domain, mgmtToken, userId: currentUserId })
+  const candidate = await getUserById({ domain, mgmtToken, userId: candidateUserId })
+
+  const primary = choosePrimaryUser(current, candidate)
+  const secondary = primary.user_id === current.user_id ? candidate : current
+
+  const secondaryIdentity = secondary.identities?.[0]
+  if (!secondaryIdentity?.provider || !secondaryIdentity?.user_id) {
+    throw new Error("Secondary identity is missing provider data")
+  }
+
+  const alreadyLinked = (primary.identities ?? []).some(
+    (identity) =>
+      identity.provider === secondaryIdentity.provider &&
+      identity.user_id === secondaryIdentity.user_id,
+  )
+
+  if (alreadyLinked) {
+    return
+  }
+
+  await linkIdentity({
+    domain,
+    mgmtToken,
+    primaryUserId: primary.user_id,
+    secondaryProvider: secondaryIdentity.provider,
+    secondaryUserId: secondaryIdentity.user_id,
+  })
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -20,7 +20,8 @@ export async function proxy(request: NextRequest) {
   const auth0 = createAuth0Client(request.nextUrl.origin)
   const { pathname } = request.nextUrl
   const isAuthRoute = pathname.startsWith("/api/auth")
-  const isPublicRoute = PUBLIC_PATHS.has(pathname) || pathname.startsWith("/login")
+  const isPublicRoute =
+    PUBLIC_PATHS.has(pathname) || pathname.startsWith("/login") || pathname.startsWith("/auth/account-link")
 
   if (isAuthRoute) {
     return auth0.middleware(request)


### PR DESCRIPTION
## Summary
This PR adds a secure Auth0 account-linking flow for users who sign in with multiple providers (for example, Google OAuth + email/password).

Resolves #86 

### What changed
- Added a new account-link confirmation page at `/auth/account-link`
- Added server-side account-linking helpers to:
  - validate the Action redirect token
  - call the Auth0 Management API
  - link identities safely
  - continue the Auth0 login flow
- Updated route protection to allow `/auth/account-link` as a public route so users can complete linking before session finalization

## Why
Users can end up with separate Auth0 identities for the same email when using different login providers. This flow lets them merge identities cleanly and continue sign-in without duplicate app accounts.

## Testing
- `npm run build`
- create an account with google
- signup with same account and you should get an account linking warning as seen here:
<img width="595" height="640" alt="Screenshot 2026-05-03 at 6 04 12 AM" src="https://github.com/user-attachments/assets/a42360dc-bf82-4485-b4ea-051fd5486ee2" />


## Notes
- This PR is designed to work with an Auth0 **Post Login Action** that redirects to `/auth/account-link` with `state` and `account_link_token`.
- Required Auth0 Management API scopes: `read:users`, `update:users`.