### PR TITLE
Fix timezone handling — use Pittsburgh (EDT) for all dates

### DIFF
--- a/app/courses/[courseId]/assessments/[assignmentId]/edit/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/edit/page.tsx
@@ -1,18 +1,11 @@
 import { notFound } from "next/navigation"
-import { format } from "date-fns"
 import { DashboardHeader } from "@/components/dashboard-header"
+import { toDateValuePittsburgh, toTimeValuePittsburgh } from "@/lib/format-date"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { EditAssignmentForm } from "./_components/edit-assignment-form"
 import { getAssessmentForGrader } from "@/lib/course-management"
 import { requireAppUser } from "@/lib/current-user"
 
-function toDateValue(iso: string) {
-  return format(new Date(iso), "yyyy-MM-dd")
-}
-
-function toTimeValue(iso: string) {
-  return format(new Date(iso), "HH:mm")
-}
 
 
 export default async function EditAssessmentPage({
@@ -62,12 +55,12 @@ export default async function EditAssessmentPage({
               initialValues={{
                 title: assessment.title,
                 description: assessment.description ?? "",
-                startDate: toDateValue(assessment.releaseAt),
-                startTime: toTimeValue(assessment.releaseAt),
-                endDate: toDateValue(assessment.dueAt),
-                endTime: toTimeValue(assessment.dueAt),
-                lateUntilDate: assessment.lateUntil ? toDateValue(assessment.lateUntil) : "",
-                lateUntilTime: assessment.lateUntil ? toTimeValue(assessment.lateUntil) : "",
+                startDate: toDateValuePittsburgh(assessment.releaseAt),
+                startTime: toTimeValuePittsburgh(assessment.releaseAt),
+                endDate: toDateValuePittsburgh(assessment.dueAt),
+                endTime: toTimeValuePittsburgh(assessment.dueAt),
+                lateUntilDate: assessment.lateUntil ? toDateValuePittsburgh(assessment.lateUntil) : "",
+                lateUntilTime: assessment.lateUntil ? toTimeValuePittsburgh(assessment.lateUntil) : "",
                 allowResubmissions: assessment.allowResubmissions,
                 maxAttemptResubmission: assessment.maxAttemptResubmission,
               }}

--- a/app/courses/[courseId]/assessments/[assignmentId]/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { format } from "date-fns"
+import { formatPittsburghTime } from "@/lib/format-date"
 import { AssessmentSubmissionPanel } from "@/components/assessment-submission-panel"
 import { AssignZeroButton } from "@/components/assign-zero-button"
 import { DashboardHeader } from "@/components/dashboard-header"
@@ -71,11 +71,11 @@ export default async function AssessmentPage({
               </p>
             )}
             <p className="mt-1 text-sm text-muted-foreground">
-              Due {format(new Date(assessment.dueAt), "MMM d, yyyy h:mm a")}
+              Due {formatPittsburghTime(assessment.dueAt, "MMM d, yyyy h:mm a")}
             </p>
             {assessment.lateUntil && (
               <p className="mt-1 text-sm text-amber-600">
-                Late submissions accepted until {format(new Date(assessment.lateUntil), "MMM d, yyyy h:mm a")}
+                Late submissions accepted until {formatPittsburghTime(assessment.lateUntil, "MMM d, yyyy h:mm a")}
               </p>
             )}
           </div>

--- a/app/courses/[courseId]/assessments/[assignmentId]/students/[studentMembershipId]/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/students/[studentMembershipId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { format } from "date-fns"
+import { formatPittsburghTime } from "@/lib/format-date"
 import { DashboardHeader } from "@/components/dashboard-header"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -94,7 +94,7 @@ export default async function StudentVersionsPage({
                     <p className="text-sm text-muted-foreground">
                       Submitted:{" "}
                       <span className="font-medium text-foreground">
-                        {format(new Date(version.submittedAt), "MMM d, yyyy h:mm a")}
+                        {formatPittsburghTime(version.submittedAt, "MMM d, yyyy h:mm a")}
                       </span>
                     </p>
                     <p className="text-sm text-muted-foreground">

--- a/app/courses/[courseId]/assessments/[assignmentId]/submissions/[submissionId]/grade/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/submissions/[submissionId]/grade/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { format } from "date-fns"
+import { formatPittsburghTime } from "@/lib/format-date"
 import { DashboardHeader } from "@/components/dashboard-header"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -70,7 +70,7 @@ export default async function StudentSubmissionGradePage({
           <div>
             <h2 className="text-xl font-semibold text-foreground">{submission.assignmentTitle}</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Submitted {format(new Date(submission.submittedAt), "MMM d, yyyy h:mm a")}
+              Submitted {formatPittsburghTime(submission.submittedAt, "MMM d, yyyy h:mm a")}
             </p>
           </div>
           <Button asChild variant="outline" className="w-full sm:w-auto">
@@ -112,7 +112,7 @@ export default async function StudentSubmissionGradePage({
                 <CardTitle>Total score</CardTitle>
                 {submission.grade?.gradedAt && (
                   <CardDescription>
-                    Last graded {format(new Date(submission.grade.gradedAt), "MMM d, yyyy h:mm a")}
+                    Last graded {formatPittsburghTime(submission.grade.gradedAt, "MMM d, yyyy h:mm a")}
                   </CardDescription>
                 )}
               </CardHeader>

--- a/app/courses/[courseId]/assessments/[assignmentId]/submissions/[submissionId]/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/submissions/[submissionId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { format } from "date-fns"
+import { formatPittsburghTime } from "@/lib/format-date"
 import { DashboardHeader } from "@/components/dashboard-header"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -60,7 +60,7 @@ export default async function SubmissionPage({
             <h2 className="text-xl font-semibold text-foreground">{submission.studentName}</h2>
             <p className="mt-1 text-sm text-muted-foreground">{submission.studentEmail}</p>
             <p className="mt-1 text-sm text-muted-foreground">
-              Submitted {format(new Date(submission.submittedAt), "MMM d, yyyy h:mm a")} · Attempt {submission.attemptNumber}
+              Submitted {formatPittsburghTime(submission.submittedAt, "MMM d, yyyy h:mm a")} · Attempt {submission.attemptNumber}
             </p>
           </div>
           <Button asChild variant="outline" className="w-full sm:w-auto">
@@ -121,7 +121,7 @@ export default async function SubmissionPage({
                 </CardHeader>
                 <CardContent className="space-y-2 text-sm">
                   <p className="text-muted-foreground">
-                    Submitted {format(new Date(submission.regradeRequest.createdAt), "MMM d, yyyy h:mm a")} by {submission.studentName}
+                    Submitted {formatPittsburghTime(submission.regradeRequest.createdAt, "MMM d, yyyy h:mm a")} by {submission.studentName}
                   </p>
                   <p className="whitespace-pre-wrap leading-relaxed text-foreground">
                     {submission.regradeRequest.reason}

--- a/app/courses/[courseId]/assessments/actions.ts
+++ b/app/courses/[courseId]/assessments/actions.ts
@@ -7,6 +7,7 @@ import { and, eq } from "drizzle-orm"
 import { db } from "@/db/orm"
 import { assignments, courseMemberships, courses } from "@/db/schema"
 import { requireAppUser } from "@/lib/current-user"
+import { pittsburghToUtcIso, pittsburghBoundaryMs } from "@/lib/format-date"
 
 type AssignmentFormState = {
   errors?: {
@@ -111,16 +112,6 @@ const createAssignmentSchema = assignmentFieldsSchema.superRefine((data, ctx) =>
   }
 })
 
-function isoFromDateTime(date: string, time: string, endOfDayFallback = false) {
-  const normalizedTime = time?.trim()
-  if (normalizedTime) {
-    // Accept "HH:mm" or "HH:mm:ss"
-    const full = normalizedTime.length === 5 ? `${normalizedTime}:00.000Z` : `${normalizedTime}.000Z`
-    return new Date(`${date}T${full}`).toISOString()
-  }
-
-  return new Date(`${date}T${endOfDayFallback ? "23:59:59.999Z" : "00:00:00.000Z"}`).toISOString()
-}
 
 async function requireActiveGraderMembership(courseId: number, userId: number) {
   const membership = await db
@@ -281,16 +272,16 @@ export async function createAssignmentAction(
     return { errors: { _form: ["Course not found."] }, values }
   }
 
-  const courseStartAt = new Date(`${course.startDate}T00:00:00.000Z`).getTime()
-  const courseEndAt = new Date(`${course.endDate}T23:59:59.999Z`).getTime()
+  const courseStartAt = pittsburghBoundaryMs(course.startDate, false)
+  const courseEndAt = pittsburghBoundaryMs(course.endDate, true)
 
   const releaseAt = parsed.data.startDate
-    ? isoFromDateTime(parsed.data.startDate, parsed.data.startTime ?? "", false)
+    ? pittsburghToUtcIso(parsed.data.startDate, parsed.data.startTime ?? "", false)
     : new Date().toISOString()
 
   // If the user does not provide an end date/time, default to the course end.
   const dueAt = parsed.data.endDate
-    ? isoFromDateTime(parsed.data.endDate, parsed.data.endTime ?? "", true)
+    ? pittsburghToUtcIso(parsed.data.endDate, parsed.data.endTime ?? "", true)
     : new Date(courseEndAt).toISOString()
 
   const releaseAtMs = new Date(releaseAt).getTime()
@@ -340,7 +331,7 @@ export async function createAssignmentAction(
     if (!parsed.data.endDate) {
       return { errors: { lateUntilDate: ["Invalid late deadline date"] }, values }
     }
-    lateUntil = isoFromDateTime(values.lateUntilDate, values.lateUntilTime, true)
+    lateUntil = pittsburghToUtcIso(values.lateUntilDate, values.lateUntilTime, true)
     const lateUntilMs = new Date(lateUntil).getTime()
     if (lateUntilMs <= dueAtMs || lateUntilMs > courseEndAt) {
       return { errors: { lateUntilDate: ["Invalid late deadline date"] }, values }
@@ -440,15 +431,15 @@ export async function updateAssignmentAction(
     return { errors: { _form: ["Course not found."] }, values }
   }
 
-  const courseStartAt = new Date(`${course.startDate}T00:00:00.000Z`).getTime()
-  const courseEndAt = new Date(`${course.endDate}T23:59:59.999Z`).getTime()
+  const courseStartAt = pittsburghBoundaryMs(course.startDate, false)
+  const courseEndAt = pittsburghBoundaryMs(course.endDate, true)
 
   const releaseAt = parsed.data.startDate
-    ? isoFromDateTime(parsed.data.startDate, parsed.data.startTime ?? "", false)
+    ? pittsburghToUtcIso(parsed.data.startDate, parsed.data.startTime ?? "", false)
     : new Date().toISOString()
 
   const dueAt = parsed.data.endDate
-    ? isoFromDateTime(parsed.data.endDate, parsed.data.endTime ?? "", true)
+    ? pittsburghToUtcIso(parsed.data.endDate, parsed.data.endTime ?? "", true)
     : new Date(courseEndAt).toISOString()
 
   const releaseAtMs = new Date(releaseAt).getTime()
@@ -496,7 +487,7 @@ export async function updateAssignmentAction(
     if (!parsed.data.endDate) {
       return { errors: { lateUntilDate: ["Invalid late deadline date"] }, values }
     }
-    lateUntil = isoFromDateTime(values.lateUntilDate, values.lateUntilTime, true)
+    lateUntil = pittsburghToUtcIso(values.lateUntilDate, values.lateUntilTime, true)
     const lateUntilMs = new Date(lateUntil).getTime()
     if (lateUntilMs <= dueAtMs || lateUntilMs > courseEndAt) {
       return { errors: { lateUntilDate: ["Invalid late deadline date"] }, values }

--- a/app/courses/[courseId]/assessments/actions.ts
+++ b/app/courses/[courseId]/assessments/actions.ts
@@ -143,6 +143,8 @@ async function getCourseDateRange(courseId: number) {
 function validateWithinCourseRange(params: {
   courseStartAt: number
   courseEndAt: number
+  courseStartDateStr: string
+  courseEndDateStr: string
   releaseAtMs: number
   dueAtMs: number
   hasExplicitStart: boolean
@@ -155,6 +157,8 @@ function validateWithinCourseRange(params: {
   const {
     courseStartAt,
     courseEndAt,
+    courseStartDateStr,
+    courseEndDateStr,
     releaseAtMs,
     dueAtMs,
     hasExplicitStart,
@@ -165,9 +169,7 @@ function validateWithinCourseRange(params: {
     endTime,
   } = params
 
-  const courseStartDate = new Date(courseStartAt).toISOString().slice(0, 10)
-  const courseEndDate = new Date(courseEndAt).toISOString().slice(0, 10)
-  const courseRangeSuffix = `Valid course date range is ${courseStartDate} to ${courseEndDate}.`
+  const courseRangeSuffix = `Valid course date range is ${courseStartDateStr} to ${courseEndDateStr}.`
 
   if (Number.isFinite(releaseAtMs) && Number.isFinite(dueAtMs) && releaseAtMs > dueAtMs) {
     const sameDayTimeConflict = Boolean(
@@ -303,6 +305,8 @@ export async function createAssignmentAction(
   const rangeErrors = validateWithinCourseRange({
     courseStartAt,
     courseEndAt,
+    courseStartDateStr: course.startDate,
+    courseEndDateStr: course.endDate,
     releaseAtMs,
     dueAtMs,
     hasExplicitStart: Boolean(parsed.data.startDate),
@@ -459,6 +463,8 @@ export async function updateAssignmentAction(
   const rangeErrors = validateWithinCourseRange({
     courseStartAt,
     courseEndAt,
+    courseStartDateStr: course.startDate,
+    courseEndDateStr: course.endDate,
     releaseAtMs,
     dueAtMs,
     hasExplicitStart: Boolean(parsed.data.startDate),

--- a/app/courses/[courseId]/page.tsx
+++ b/app/courses/[courseId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
 import { format, parseISO } from "date-fns"
+import { formatPittsburghTime } from "@/lib/format-date"
 import { DashboardHeader } from "@/components/dashboard-header"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -106,7 +107,7 @@ export default async function CourseDashboardPage({
                       {assignment.description}
                     </CardDescription>
                   )}
-                  <CardDescription>Due {format(new Date(assignment.dueAt), "MMM d, yyyy h:mm a")}</CardDescription>
+                  <CardDescription>Due {formatPittsburghTime(assignment.dueAt, "MMM d, yyyy h:mm a")}</CardDescription>
                 </CardHeader>
                 <CardContent className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
                   {isInstructor && <p className="text-sm text-muted-foreground">

--- a/components/assessment-submission-panel.tsx
+++ b/components/assessment-submission-panel.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { useRef, useState } from "react"
 import { useRouter } from "next/navigation"
-import { format } from "date-fns"
+import { formatPittsburghTime } from "@/lib/format-date"
 import { Calendar, ExternalLink, FileText, RotateCcw, UploadCloud } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -178,12 +178,12 @@ export function AssessmentSubmissionPanel({
                 <p className="text-lg font-semibold text-foreground">{assignmentTitle}</p>
                 <p className="mt-0.5 flex items-center gap-1 text-sm text-muted-foreground">
                   <Calendar className="size-3.5" />
-                  Due {format(dueDate, "MMM d, yyyy 'at' h:mm a")}
+                  Due {formatPittsburghTime(dueDate, "MMM d, yyyy 'at' h:mm a")}
                 </p>
                 {lateDate && (
                   <p className="mt-0.5 flex items-center gap-1 text-sm text-amber-600">
                     <Calendar className="size-3.5" />
-                    Late submissions accepted until {format(lateDate, "MMM d, yyyy 'at' h:mm a")}
+                    Late submissions accepted until {formatPittsburghTime(lateDate, "MMM d, yyyy 'at' h:mm a")}
                   </p>
                 )}
               </div>
@@ -218,7 +218,7 @@ export function AssessmentSubmissionPanel({
 
           {!isInstructor && !uploadDisabled && !inLateWindow && (
             <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
-              Submit before {format(dueDate, "MMM d, yyyy 'at' h:mm a")}.
+              Submit before {formatPittsburghTime(dueDate, "MMM d, yyyy 'at' h:mm a")}.
             </div>
           )}
 
@@ -284,7 +284,7 @@ export function AssessmentSubmissionPanel({
                       </Badge>
                     </div>
                     <p className="text-sm text-muted-foreground">
-                      {format(new Date(item.submittedAt), "MMM d, yyyy 'at' h:mm a")}
+                      {formatPittsburghTime(item.submittedAt, "MMM d, yyyy 'at' h:mm a")}
                     </p>
                   </div>
                 </div>

--- a/components/student-submissions-card.tsx
+++ b/components/student-submissions-card.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useState } from "react"
-import { format } from "date-fns"
+import { formatPittsburghTime } from "@/lib/format-date"
 import { ChevronDown, ChevronUp } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -46,7 +46,7 @@ export function StudentSubmissionsCard({ courseId, assignmentId, versions, hasPe
               <span className={`text-xs font-medium capitalize ${current.status === "late" ? "text-amber-700" : "text-muted-foreground"}`}>{current.status}</span>
             </div>
             <p className="text-xs text-muted-foreground">
-              {format(new Date(current.submittedAt), "MMM d, yyyy 'at' h:mm a")}
+              {formatPittsburghTime(current.submittedAt, "MMM d, yyyy 'at' h:mm a")}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -101,7 +101,7 @@ export function StudentSubmissionsCard({ courseId, assignmentId, versions, hasPe
                         <span className={`text-xs font-medium capitalize ${v.status === "late" ? "text-amber-700" : "text-muted-foreground"}`}>{v.status}</span>
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        {format(new Date(v.submittedAt), "MMM d, yyyy 'at' h:mm a")}
+                        {formatPittsburghTime(v.submittedAt, "MMM d, yyyy 'at' h:mm a")}
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">

--- a/lib/format-date.ts
+++ b/lib/format-date.ts
@@ -1,0 +1,26 @@
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz"
+
+export const PITTSBURGH_TZ = "America/New_York"
+
+export function formatPittsburghTime(date: string | Date, formatStr: string): string {
+  return formatInTimeZone(new Date(date), PITTSBURGH_TZ, formatStr)
+}
+
+export function pittsburghToUtcIso(date: string, time: string, endOfDayFallback = false): string {
+  const normalizedTime = time?.trim()
+  const t = normalizedTime ? normalizedTime : endOfDayFallback ? "23:59:59" : "00:00:00"
+  return fromZonedTime(new Date(`${date}T${t}`), PITTSBURGH_TZ).toISOString()
+}
+
+export function toDateValuePittsburgh(iso: string): string {
+  return formatInTimeZone(new Date(iso), PITTSBURGH_TZ, "yyyy-MM-dd")
+}
+
+export function toTimeValuePittsburgh(iso: string): string {
+  return formatInTimeZone(new Date(iso), PITTSBURGH_TZ, "HH:mm")
+}
+
+export function pittsburghBoundaryMs(date: string, endOfDay = false): number {
+  const t = endOfDay ? "23:59:59.999" : "00:00:00.000"
+  return fromZonedTime(new Date(`${date}T${t}`), PITTSBURGH_TZ).getTime()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
                 "clsx": "^2.1.1",
                 "cmdk": "1.1.1",
                 "date-fns": "4.1.0",
+                "date-fns-tz": "^3.2.0",
                 "drizzle-orm": "^0.45.1",
                 "embla-carousel-react": "8.6.0",
                 "input-otp": "1.4.2",
@@ -8508,6 +8509,15 @@
         "node_modules/date-fns-jalali": {
             "version": "4.1.0-0",
             "license": "MIT"
+        },
+        "node_modules/date-fns-tz": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+            "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "date-fns": "^3.0.0 || ^4.0.0"
+            }
         },
         "node_modules/debug": {
             "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "clsx": "^2.1.1",
         "cmdk": "1.1.1",
         "date-fns": "4.1.0",
+        "date-fns-tz": "^3.2.0",
         "drizzle-orm": "^0.45.1",
         "embla-carousel-react": "8.6.0",
         "input-otp": "1.4.2",

--- a/tests/assignments/create-assignment-action.jest.test.ts
+++ b/tests/assignments/create-assignment-action.jest.test.ts
@@ -250,8 +250,8 @@ test("updateAssignmentAction updates assignment and redirects on success", async
     expect.objectContaining({
       title: "HW1 Updated",
       description: "Updated",
-      releaseAt: "2026-03-06T10:00:00.000Z",
-      dueAt: "2026-03-12T17:30:00.000Z",
+      releaseAt: "2026-03-06T15:00:00.000Z",
+      dueAt: "2026-03-12T21:30:00.000Z",
     }),
   )
   expect(mockRevalidatePath).toHaveBeenCalledWith("/courses/34/assessments/7")

--- a/tests/assignments/create-assignment-action.test.ts
+++ b/tests/assignments/create-assignment-action.test.ts
@@ -72,7 +72,7 @@ describe("createAssignmentAction", () => {
       expect.objectContaining({
         totalPoints: 0,
         releaseAt: "2026-03-05T12:00:00.000Z",
-        dueAt: "2026-03-10T23:59:59.999Z",
+        dueAt: "2026-03-11T03:59:59.999Z",
       }),
     )
 
@@ -96,8 +96,8 @@ describe("createAssignmentAction", () => {
 
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
-        releaseAt: "2026-03-02T08:15:00.000Z",
-        dueAt: "2026-03-10T23:59:59.999Z",
+        releaseAt: "2026-03-02T13:15:00.000Z",
+        dueAt: "2026-03-11T03:59:59.999Z",
       }),
     )
   })
@@ -123,7 +123,7 @@ describe("createAssignmentAction", () => {
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         releaseAt: "2026-03-05T12:00:00.000Z",
-        dueAt: "2026-03-06T09:00:00.000Z",
+        dueAt: "2026-03-06T14:00:00.000Z",
       }),
     )
 

--- a/tests/assignments/update-assignment-action.test.ts
+++ b/tests/assignments/update-assignment-action.test.ts
@@ -133,8 +133,8 @@ describe("updateAssignmentAction", () => {
       expect.objectContaining({
         title: "HW1 Updated",
         description: "New desc",
-        releaseAt: "2026-03-03T10:30:00.000Z",
-        dueAt: "2026-03-10T18:00:00.000Z",
+        releaseAt: "2026-03-03T15:30:00.000Z",
+        dueAt: "2026-03-10T22:00:00.000Z",
       }),
     )
 


### PR DESCRIPTION
## Summary
- Assignment deadlines entered by instructors were being stored as UTC instead of Pittsburgh (EDT) time, causing deadlines to fire 4 hours early
- All date displays were inconsistent — server components rendered UTC, client components rendered browser-local time
- Introduces a shared `lib/format-date.ts` utility and fixes all input/display paths end-to-end

## Linked Issue
- Closes #83

## Changes
### Backend
- Added `lib/format-date.ts` with `pittsburghToUtcIso`, `pittsburghBoundaryMs`, `formatPittsburghTime`, `toDateValuePittsburgh`, `toTimeValuePittsburgh` using `date-fns-tz`
- Replaced `isoFromDateTime` in `assessments/actions.ts` with `pittsburghToUtcIso` — instructor-entered times are now correctly converted from EDT to UTC before storage
- Fixed course date boundary calculations in both create and update actions to use Pittsburgh midnight instead of UTC midnight

### Frontend
- Edit form (`edit/page.tsx`) now pre-populates date/time inputs using Pittsburgh-converted values
- All `format(new Date(...))` calls in assessment page, course dashboard, submission pages, grade page, student versions page, `assessment-submission-panel`, and `student-submissions-card` replaced with `formatPittsburghTime`

### Tests
- No automated tests added; manual verification required (see below)

## Risks / Assumptions
- Existing assignments in the database were stored with the old UTC-as-local bug — their stored `dueAt` values are 4 hours off. This fix applies going forward; existing records may need a one-time data migration
- This hardcodes `America/New_York` as the app timezone. Appropriate for a Pittsburgh-only product; would need revisiting for multi-timezone support

## Validation
- [ ] Create a new assignment with due time "11:59 PM" — verify both header and card show 11:59 PM
- [ ] Edit an existing assignment — verify date/time inputs pre-fill with Pittsburgh time
- [ ] Submit an assignment — verify `submittedAt` displays in Pittsburgh time across all views
- [ ] Manual verification completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized date and time displays across the application for consistency. Assessment due dates, submission timestamps, and deadline information now display using a consistent timezone format throughout the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->