### PR TITLE
Strict course date validation: On/after 2026

### DIFF
--- a/app/courses/actions.ts
+++ b/app/courses/actions.ts
@@ -40,6 +40,30 @@ const courseFieldsSchema = z.object({
 })
 
 const createSchema = courseFieldsSchema.superRefine((data, ctx) => {
+  const minimumYear = 2026
+
+  if (data.startDate) {
+    const startYear = new Date(data.startDate).getFullYear()
+    if (Number.isNaN(startYear) || startYear < minimumYear) {
+      ctx.addIssue({
+        path: ["startDate"],
+        code: z.ZodIssueCode.custom,
+        message: `Start date must be in ${minimumYear} or later`,
+      })
+    }
+  }
+
+  if (data.endDate) {
+    const endYear = new Date(data.endDate).getFullYear()
+    if (Number.isNaN(endYear) || endYear < minimumYear) {
+      ctx.addIssue({
+        path: ["endDate"],
+        code: z.ZodIssueCode.custom,
+        message: `End date must be in ${minimumYear} or later`,
+      })
+    }
+  }
+
   if (data.startDate && data.endDate && data.endDate < data.startDate) {
     ctx.addIssue({
       path: ["endDate"],

--- a/app/courses/new/page.tsx
+++ b/app/courses/new/page.tsx
@@ -21,7 +21,7 @@ export default async function CreateCoursePage() {
         <div className="mb-5">
           <h2 className="text-xl font-semibold text-foreground">New course</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            Title is required. If both dates are provided, end date must be on or after start date.
+            Title is required. Dates must be in 2026 or later, and end date must be on or after start date.
           </p>
         </div>
         <CreateCourseForm />

--- a/components/create-course-form.tsx
+++ b/components/create-course-form.tsx
@@ -36,6 +36,7 @@ export function CreateCourseForm() {
             id="startDate"
             name="startDate"
             type="date"
+            min="2026-01-01"
             defaultValue={state.values?.startDate ?? ""}
             aria-invalid={!!state.errors?.startDate}
           />
@@ -48,6 +49,7 @@ export function CreateCourseForm() {
             id="endDate"
             name="endDate"
             type="date"
+            min="2026-01-01"
             defaultValue={state.values?.endDate ?? ""}
             aria-invalid={!!state.errors?.endDate}
           />


### PR DESCRIPTION
## Linked Issue
- Closes https://github.com/KesterTan/GradienceV2/issues/78

## Summary
- Prevent course creation with dates before 2026 and align UI guidance with the new constraint.

## Linked Issue
- Closes #<issue-number>

## Changes
### Backend
- Add server-side validation to reject start/end dates earlier than 2026.

### Frontend
- Add min date constraint on date inputs.
- Update helper copy to reflect 2026+ requirement.

### Tests
- Not run (not requested).

## Risks / Assumptions
- Assumes any course before 2026 should be invalid.

## Validation
- [ ] Tests run
- [ ] Manual verification completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Course date validation now enforces a minimum year of 2026 for start and end dates.
  * Date input fields updated with visual minimum date constraints.

* **Documentation**
  * Helper text updated to clarify date requirements, specifying 2026 or later and end date constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->