### PR TITLE
Updated the authenticated breadcrumb Home link

### DIFF
--- a/app/courses/[courseId]/assessments/[assignmentId]/edit/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/edit/page.tsx
@@ -41,7 +41,7 @@ export default async function EditAssessmentPage({
         title="Edit assignment"
         subtitle={assessment.title}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: assessment.courseTitle, href: `/courses/${assessment.courseId}` },
           { label: assessment.title, href: `/courses/${assessment.courseId}/assessments/${assessment.id}` },
           { label: "Edit", current: true },

--- a/app/courses/[courseId]/assessments/[assignmentId]/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/page.tsx
@@ -52,7 +52,7 @@ export default async function AssessmentPage({
         title="Assessment page"
         subtitle={assessment.title}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: assessment.courseTitle, href: `/courses/${assessment.courseId}` },
           { label: assessment.title, current: true },
         ]}

--- a/app/courses/[courseId]/assessments/[assignmentId]/questions/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/questions/page.tsx
@@ -37,7 +37,7 @@ export default async function AssessmentQuestionsPage({
         title="Questions"
         subtitle={assessment.title}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: assessment.courseTitle, href: `/courses/${assessment.courseId}` },
           { label: assessment.title, href: `/courses/${assessment.courseId}/assessments/${assessment.id}` },
           { label: "Questions", current: true },

--- a/app/courses/[courseId]/assessments/[assignmentId]/rubric/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/rubric/page.tsx
@@ -37,7 +37,7 @@ export default async function AssessmentRubricPage({
         title="Rubric"
         subtitle={assessment.title}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: assessment.courseTitle, href: `/courses/${assessment.courseId}` },
           { label: assessment.title, href: `/courses/${assessment.courseId}/assessments/${assessment.id}` },
           { label: "Rubric", current: true },

--- a/app/courses/[courseId]/assessments/[assignmentId]/students/[studentMembershipId]/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/students/[studentMembershipId]/page.tsx
@@ -58,7 +58,7 @@ export default async function StudentVersionsPage({
         title="Submission versions"
         subtitle={`${result.studentName} · ${assessment.title}`}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: assessment.courseTitle, href: `/courses/${assessment.courseId}` },
           { label: assessment.title, href: `/courses/${assessment.courseId}/assessments/${assessment.id}` },
           { label: result.studentName, current: true },

--- a/app/courses/[courseId]/assessments/[assignmentId]/submissions/[submissionId]/grade/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/submissions/[submissionId]/grade/page.tsx
@@ -54,7 +54,7 @@ export default async function StudentSubmissionGradePage({
         title="My grade"
         subtitle={`${submission.assignmentTitle} · Attempt ${submission.attemptNumber}`}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: submission.courseTitle, href: `/courses/${submission.courseId}` },
           {
             label: submission.assignmentTitle,

--- a/app/courses/[courseId]/assessments/[assignmentId]/submissions/[submissionId]/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/submissions/[submissionId]/page.tsx
@@ -46,7 +46,7 @@ export default async function SubmissionPage({
         title="Submission"
         subtitle={`${submission.studentName} · ${submission.assignmentTitle}`}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: submission.courseTitle, href: `/courses/${submission.courseId}` },
           { label: submission.assignmentTitle, href: `/courses/${submission.courseId}/assessments/${submission.assignmentId}` },
           { label: submission.studentName, current: true },

--- a/app/courses/[courseId]/assessments/new/page.tsx
+++ b/app/courses/[courseId]/assessments/new/page.tsx
@@ -22,7 +22,7 @@ export default async function CreateAssessmentPage({
           title="Create assignment"
           subtitle="Invalid course"
           breadcrumbs={[
-            { label: "Home", href: "/" },
+            { label: "Home", href: "/courses" },
             { label: "Courses", href: "/courses" },
             { label: "Create assignment", current: true },
           ]}
@@ -53,7 +53,7 @@ export default async function CreateAssessmentPage({
           title="Create assignment"
           subtitle="Course not found"
           breadcrumbs={[
-            { label: "Home", href: "/" },
+            { label: "Home", href: "/courses" },
             { label: "Courses", href: "/courses" },
             { label: "Create assignment", current: true },
           ]}
@@ -87,7 +87,7 @@ export default async function CreateAssessmentPage({
         title="Create assignment"
         subtitle={course.title}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: course.title, href: `/courses/${course.id}` },
           { label: "Create assignment", current: true },
         ]}

--- a/app/courses/[courseId]/manage/page.tsx
+++ b/app/courses/[courseId]/manage/page.tsx
@@ -23,7 +23,7 @@ export default async function ManageCoursePage({
           title="Manage course"
           subtitle="Invalid course"
           breadcrumbs={[
-            { label: "Home", href: "/" },
+            { label: "Home", href: "/courses" },
             { label: "Courses", href: "/courses" },
             { label: "Manage course", current: true },
           ]}
@@ -54,7 +54,7 @@ export default async function ManageCoursePage({
           title="Manage course"
           subtitle="Course not found"
           breadcrumbs={[
-            { label: "Home", href: "/" },
+            { label: "Home", href: "/courses" },
             { label: "Courses", href: "/courses" },
             { label: "Manage course", current: true },
           ]}
@@ -89,7 +89,7 @@ export default async function ManageCoursePage({
           title="Manage course"
           subtitle={course.title}
           breadcrumbs={[
-            { label: "Home", href: "/" },
+            { label: "Home", href: "/courses" },
             { label: course.title, href: `/courses/${course.id}` },
             { label: "Manage course", current: true },
           ]}
@@ -118,7 +118,7 @@ export default async function ManageCoursePage({
         title="Manage course"
         subtitle={course.title}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: course.title, href: `/courses/${course.id}` },
           { label: "Manage course", current: true },
         ]}

--- a/app/courses/[courseId]/members/page.tsx
+++ b/app/courses/[courseId]/members/page.tsx
@@ -20,7 +20,7 @@ export default async function MembersPage({ params }: { params: { courseId: stri
         title="Manage Members"
         subtitle={courseTitle || undefined}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: courseTitle || "Course", href: `/courses/${resolvedParams.courseId}` },
           { label: "Members", current: true },
         ]}

--- a/app/courses/[courseId]/page.tsx
+++ b/app/courses/[courseId]/page.tsx
@@ -42,7 +42,7 @@ export default async function CourseDashboardPage({
         title="Course dashboard"
         subtitle={course.title}
         breadcrumbs={[
-          { label: "Home", href: "/" },
+          { label: "Home", href: "/courses" },
           { label: course.title, current: true },
         ]}
         user={{ name: `${user.firstName} ${user.lastName}`, email: user.email }}

--- a/tests/assignments/course-dashboard-assignments-ui.test.ts
+++ b/tests/assignments/course-dashboard-assignments-ui.test.ts
@@ -59,5 +59,34 @@ describe("Course dashboard assignments UI", () => {
     expect(html).toContain("Intro problems")
     expect(html).toContain("/courses/34/assessments/7")
   })
+
+  it("links the breadcrumb home icon to the courses dashboard", async () => {
+    mocks.requireAppUser.mockResolvedValue({
+      id: 42,
+      firstName: "Irene",
+      lastName: "Instructor",
+      email: "irene@gradience.edu",
+    })
+
+    mocks.getCourseForGrader.mockResolvedValue({
+      id: 34,
+      title: "Intro to Systems",
+      startDate: "2026-03-01",
+      endDate: "2026-05-01",
+      instructors: ["Irene Instructor"],
+      viewerRole: "Instructor",
+    })
+
+    mocks.listAssignmentsForCourse.mockResolvedValue([])
+
+    const element = await CourseDashboardPage({
+      params: Promise.resolve({ courseId: "34" }),
+    })
+
+    const html = renderToStaticMarkup(element as unknown as React.ReactElement)
+
+    expect(html).toContain("aria-label=\"Go to home\"")
+    expect(html).toContain("href=\"/courses\"")
+  })
 })
 


### PR DESCRIPTION
## Linked User Story
- Closes https://github.com/KesterTan/GradienceV2/issues/87

## Summary
- Keep authenticated users in the app by routing breadcrumb Home links to `/courses` instead of the marketing landing page.
- Add a regression test for the course dashboard breadcrumb Home link.

## Linked Issue
- Closes #<issue-number>

## Changes
### Backend
- None.

### Frontend
- Update in-app breadcrumb Home links to point to `/courses` across course, assessment, and submission pages.

### Tests
- `npm test -- tests/assignments/course-dashboard-assignments-ui.test.ts`

## Risks / Assumptions
- Assumes app “Home” should always resolve to `/courses` for authenticated flows.

## Validation
- [x] Tests run
