### PR TITLE
Sync assessment question max points with rubric totals

### DIFF
--- a/app/courses/[courseId]/assessments/[assignmentId]/questions/_components/question-editor.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/questions/_components/question-editor.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { getRubricQuestionPointMap, syncQuestionMaxPointsWithRubric } from "@/lib/assessment-points"
 import { saveQuestionsAction } from "../actions"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -8,11 +9,13 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import type { QuestionsPayload, AssignmentQuestion } from "@/lib/questions"
+import type { RubricPayload } from "@/lib/rubrics"
 
 type QuestionEditorProps = {
   courseId: number
   assignmentId: number
   initialPayload: QuestionsPayload | null
+  rubric?: RubricPayload | null
   canEdit: boolean
   assignmentTitle: string
   courseTitle: string
@@ -86,6 +89,7 @@ export function QuestionEditor({
   courseId,
   assignmentId,
   initialPayload,
+  rubric = null,
   canEdit,
   assignmentTitle,
   courseTitle,
@@ -114,19 +118,26 @@ export function QuestionEditor({
 
   const effectiveAssignmentTitle = savedAssignmentTitle || assignmentTitle
   const effectiveCourseTitle = savedCourse || courseTitle
+  const rubricPointMap = getRubricQuestionPointMap(rubric)
+  const hasRubricPoints = rubricPointMap.size > 0
 
   const [savedQuestions, setSavedQuestions] = useState<AssignmentQuestion[]>(
-    () => initialPayload?.questions ?? [],
+    () => syncQuestionMaxPointsWithRubric(initialPayload?.questions ?? [], rubric),
   )
   const [questions, setQuestions] = useState<AssignmentQuestion[]>(() => {
     if (!initialPayload?.questions?.length) return [emptyQuestion(0)]
-    return initialPayload.questions.map((q) => ({
+    return syncQuestionMaxPointsWithRubric(initialPayload.questions, rubric).map((q) => ({
       question_id: q.question_id,
       question_text: q.question_text,
       question_max_total: q.question_max_total,
       is_extra_credit: q.is_extra_credit ?? false,
     }))
   })
+  const effectiveSavedQuestions = syncQuestionMaxPointsWithRubric(savedQuestions, rubric)
+  const effectiveQuestions = syncQuestionMaxPointsWithRubric(questions, rubric)
+  const unmatchedQuestionIds = effectiveQuestions
+    .filter((question) => !rubricPointMap.has(question.question_id.trim()))
+    .map((question, index) => question.question_id.trim() || `Question ${index + 1}`)
 
   const importQuestionsJson = async (file: File) => {
     setImportError(null)
@@ -244,7 +255,7 @@ export function QuestionEditor({
         return
       }
 
-      setQuestions(normalizedQuestions)
+      setQuestions(syncQuestionMaxPointsWithRubric(normalizedQuestions, rubric))
       if (importedAssignmentTitle) setAssignmentTitleInput(importedAssignmentTitle)
       if (importedCourse) setCourseInput(importedCourse)
       if (importedInstructionsSummary) setInstructionsSummaryInput(importedInstructionsSummary)
@@ -263,7 +274,7 @@ export function QuestionEditor({
     setFieldErrors({})
 
     // Snapshot questions at the moment of submit — no stale closure risk
-    const snapshot = questions.map((q) => ({ ...q }))
+    const snapshot = effectiveQuestions.map((q) => ({ ...q }))
     const normalizedAssignmentTitleInput = assignmentTitleInput.trim()
     const normalizedCourseInput = courseInput.trim()
     const assignmentTitleForSave = normalizedAssignmentTitleInput || savedAssignmentTitle || assignmentTitle
@@ -344,7 +355,7 @@ export function QuestionEditor({
 
   const enterEditMode = () => {
     setQuestions(
-      savedQuestions.length ? savedQuestions.map((q) => ({ ...q })) : [emptyQuestion(0)],
+      effectiveSavedQuestions.length ? effectiveSavedQuestions.map((q) => ({ ...q })) : [emptyQuestion(0)],
     )
     setAssignmentTitleInput(savedAssignmentTitle)
     setCourseInput(savedCourse)
@@ -373,13 +384,13 @@ export function QuestionEditor({
             type="button"
             variant="outline"
             onClick={() =>
-              printQuestionsPdf(effectiveAssignmentTitle, effectiveCourseTitle, savedQuestions)
+              printQuestionsPdf(effectiveAssignmentTitle, effectiveCourseTitle, effectiveSavedQuestions)
             }
           >
             Download PDF
           </Button>
         </div>
-        {savedQuestions.map((q, index) => (
+        {effectiveSavedQuestions.map((q, index) => (
           <QuestionCard key={`${q.question_id}-${index}`} question={q} />
         ))}
       </div>
@@ -392,14 +403,14 @@ export function QuestionEditor({
       <div className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-sm text-muted-foreground">
-            {savedQuestions.length} question{savedQuestions.length !== 1 ? "s" : ""} saved
+            {effectiveSavedQuestions.length} question{effectiveSavedQuestions.length !== 1 ? "s" : ""} saved
           </p>
           <div className="flex gap-2">
             <Button
               type="button"
               variant="outline"
               onClick={() =>
-                printQuestionsPdf(effectiveAssignmentTitle, effectiveCourseTitle, savedQuestions)
+                printQuestionsPdf(effectiveAssignmentTitle, effectiveCourseTitle, effectiveSavedQuestions)
               }
             >
               Download PDF
@@ -409,7 +420,16 @@ export function QuestionEditor({
             </Button>
           </div>
         </div>
-        {savedQuestions.map((q, index) => (
+        {hasRubricPoints && (
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-sm text-muted-foreground">
+                Max points on this page are derived from the saved rubric. Edit the rubric to change grading totals.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+        {effectiveSavedQuestions.map((q, index) => (
           <QuestionCard key={`${q.question_id}-${index}`} question={q} />
         ))}
       </div>
@@ -455,6 +475,21 @@ export function QuestionEditor({
 
       {formError && <p className="text-sm text-destructive">{formError}</p>}
       {importError && <p className="text-sm text-destructive">{importError}</p>}
+      {hasRubricPoints && (
+        <Card>
+          <CardContent className="space-y-2 pt-6">
+            <p className="text-sm text-muted-foreground">
+              Question max points are controlled by the saved rubric for matching question IDs.
+            </p>
+            {unmatchedQuestionIds.length > 0 && (
+              <p className="text-sm text-amber-700">
+                No rubric entry matches: {unmatchedQuestionIds.join(", ")}. Update the rubric if these questions
+                should count toward the assignment total.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       <Card>
         <CardHeader>
@@ -495,88 +530,100 @@ export function QuestionEditor({
       </Card>
 
       <div className="space-y-4">
-        {questions.map((question, index) => (
-          <Card key={`question-${index}`}>
-            <CardHeader>
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <CardTitle className="text-base">Question {index + 1}</CardTitle>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => removeQuestion(index)}
-                  disabled={questions.length === 1}
-                >
-                  Delete
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid gap-4 sm:grid-cols-[1fr_auto]">
+        {questions.map((question, index) => {
+          const effectiveQuestion = effectiveQuestions[index] ?? question
+          const hasMatchingRubricPoints = rubricPointMap.has(question.question_id.trim())
+
+          return (
+            <Card key={`question-${index}`}>
+              <CardHeader>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <CardTitle className="text-base">Question {index + 1}</CardTitle>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => removeQuestion(index)}
+                    disabled={questions.length === 1}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-4 sm:grid-cols-[1fr_auto]">
+                  <div className="space-y-1">
+                    <Label htmlFor={`qid-${index}`}>Question ID</Label>
+                    <Input
+                      id={`qid-${index}`}
+                      value={question.question_id}
+                      className={errorClass(`questions.${index}.question_id`)}
+                      onChange={(e) => updateQuestion(index, { question_id: e.target.value })}
+                      placeholder={`Q${index + 1}`}
+                    />
+                    {fieldErrors[`questions.${index}.question_id`]?.[0] && (
+                      <p className="text-sm text-destructive">
+                        {fieldErrors[`questions.${index}.question_id`][0]}
+                      </p>
+                    )}
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor={`qmax-${index}`}>Max points</Label>
+                    <Input
+                      id={`qmax-${index}`}
+                      type="number"
+                      min={0}
+                      value={effectiveQuestion.question_max_total}
+                      className={errorClass(`questions.${index}.question_max_total`)}
+                      onChange={(e) =>
+                        updateQuestion(index, { question_max_total: Number(e.target.value) })
+                      }
+                      disabled={hasMatchingRubricPoints}
+                    />
+                    {hasMatchingRubricPoints && (
+                      <p className="text-xs text-muted-foreground">
+                        This value is synced from the saved rubric for{" "}
+                        {question.question_id || `Question ${index + 1}`}.
+                      </p>
+                    )}
+                    {fieldErrors[`questions.${index}.question_max_total`]?.[0] && (
+                      <p className="text-sm text-destructive">
+                        {fieldErrors[`questions.${index}.question_max_total`][0]}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
                 <div className="space-y-1">
-                  <Label htmlFor={`qid-${index}`}>Question ID</Label>
-                  <Input
-                    id={`qid-${index}`}
-                    value={question.question_id}
-                    className={errorClass(`questions.${index}.question_id`)}
-                    onChange={(e) => updateQuestion(index, { question_id: e.target.value })}
-                    placeholder={`Q${index + 1}`}
+                  <Label htmlFor={`qtext-${index}`}>Question text</Label>
+                  <Textarea
+                    id={`qtext-${index}`}
+                    value={question.question_text}
+                    className={errorClass(`questions.${index}.question_text`)}
+                    rows={3}
+                    onChange={(e) => updateQuestion(index, { question_text: e.target.value })}
+                    placeholder="Enter the question prompt..."
                   />
-                  {fieldErrors[`questions.${index}.question_id`]?.[0] && (
+                  {fieldErrors[`questions.${index}.question_text`]?.[0] && (
                     <p className="text-sm text-destructive">
-                      {fieldErrors[`questions.${index}.question_id`][0]}
+                      {fieldErrors[`questions.${index}.question_text`][0]}
                     </p>
                   )}
                 </div>
-                <div className="space-y-1">
-                  <Label htmlFor={`qmax-${index}`}>Max points</Label>
-                  <Input
-                    id={`qmax-${index}`}
-                    type="number"
-                    min={0}
-                    value={question.question_max_total}
-                    className={errorClass(`questions.${index}.question_max_total`)}
-                    onChange={(e) =>
-                      updateQuestion(index, { question_max_total: Number(e.target.value) })
-                    }
+
+                <div className="flex items-center gap-2">
+                  <input
+                    id={`qec-${index}`}
+                    type="checkbox"
+                    className="size-4 rounded border-input"
+                    checked={question.is_extra_credit ?? false}
+                    onChange={(e) => updateQuestion(index, { is_extra_credit: e.target.checked })}
                   />
-                  {fieldErrors[`questions.${index}.question_max_total`]?.[0] && (
-                    <p className="text-sm text-destructive">
-                      {fieldErrors[`questions.${index}.question_max_total`][0]}
-                    </p>
-                  )}
+                  <Label htmlFor={`qec-${index}`}>Extra credit</Label>
                 </div>
-              </div>
-
-              <div className="space-y-1">
-                <Label htmlFor={`qtext-${index}`}>Question text</Label>
-                <Textarea
-                  id={`qtext-${index}`}
-                  value={question.question_text}
-                  className={errorClass(`questions.${index}.question_text`)}
-                  rows={3}
-                  onChange={(e) => updateQuestion(index, { question_text: e.target.value })}
-                  placeholder="Enter the question prompt..."
-                />
-                {fieldErrors[`questions.${index}.question_text`]?.[0] && (
-                  <p className="text-sm text-destructive">
-                    {fieldErrors[`questions.${index}.question_text`][0]}
-                  </p>
-                )}
-              </div>
-
-              <div className="flex items-center gap-2">
-                <input
-                  id={`qec-${index}`}
-                  type="checkbox"
-                  className="size-4 rounded border-input"
-                  checked={question.is_extra_credit ?? false}
-                  onChange={(e) => updateQuestion(index, { is_extra_credit: e.target.checked })}
-                />
-                <Label htmlFor={`qec-${index}`}>Extra credit</Label>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
+              </CardContent>
+            </Card>
+          )
+        })}
 
         <Button type="button" variant="outline" className="w-full" onClick={addQuestion}>
           Add question

--- a/app/courses/[courseId]/assessments/[assignmentId]/questions/actions.ts
+++ b/app/courses/[courseId]/assessments/[assignmentId]/questions/actions.ts
@@ -4,8 +4,10 @@ import { revalidatePath } from "next/cache"
 import { and, eq } from "drizzle-orm"
 import { db } from "@/db/orm"
 import { assignments, courses, courseMemberships } from "@/db/schema"
+import { syncQuestionMaxPointsWithRubric } from "@/lib/assessment-points"
 import { requireAppUser } from "@/lib/current-user"
 import { questionsPayloadSchema, type QuestionsPayload } from "@/lib/questions"
+import { parseRubricJson } from "@/lib/rubrics"
 import { buildQuestionsS3ObjectKey, uploadQuestionsJsonToS3 } from "@/lib/s3-submissions"
 
 export type QuestionsFormState = {
@@ -88,12 +90,13 @@ export async function saveQuestionsAction(
   }
 
   const existing = await db
-    .select({ id: assignments.id })
+    .select({ id: assignments.id, rubricJson: assignments.rubricJson })
     .from(assignments)
     .where(and(eq(assignments.id, assignmentId), eq(assignments.courseId, courseId)))
     .limit(1)
 
-  if (!existing[0]) {
+  const assignment = existing[0]
+  if (!assignment) {
     return { errors: { _form: ["Assessment not found."] } }
   }
 
@@ -117,13 +120,15 @@ export async function saveQuestionsAction(
   const assignmentTitle = parsed.data.assignment_title.trim()
   const course = parsed.data.course.trim()
   const instructionsSummary = parsed.data.instructions_summary.trim()
+  const rubric = parseRubricJson(assignment.rubricJson)
+  const syncedQuestions = syncQuestionMaxPointsWithRubric(parsed.data.questions, rubric)
 
   const questionsJson: QuestionsPayload = {
     assignment_title: assignmentTitle.length > 0 ? assignmentTitle : meta.title,
     course: course.length > 0 ? course : meta.courseTitle,
     instructions_summary:
       instructionsSummary.length > 0 ? instructionsSummary : meta.description ?? "",
-    questions: parsed.data.questions,
+    questions: syncedQuestions,
   }
 
   try {

--- a/app/courses/[courseId]/assessments/[assignmentId]/questions/page.tsx
+++ b/app/courses/[courseId]/assessments/[assignmentId]/questions/page.tsx
@@ -7,6 +7,7 @@ import { QuestionEditor } from "./_components/question-editor"
 import { getAssessmentQuestionsForMember } from "@/lib/course-management"
 import { requireAppUser } from "@/lib/current-user"
 import { parseQuestionsJson } from "@/lib/questions"
+import { parseRubricJson } from "@/lib/rubrics"
 
 export default async function AssessmentQuestionsPage({
   params,
@@ -30,6 +31,7 @@ export default async function AssessmentQuestionsPage({
 
   const isInstructor = assessment.viewerRole === "Instructor"
   const questions = parseQuestionsJson(assessment.questionsJson)
+  const rubric = parseRubricJson(assessment.rubricJson)
 
   return (
     <main className="min-h-screen bg-muted/30">
@@ -81,6 +83,7 @@ export default async function AssessmentQuestionsPage({
             courseId={assessment.courseId}
             assignmentId={assessment.id}
             initialPayload={questions}
+            rubric={rubric}
             canEdit={isInstructor}
             assignmentTitle={assessment.title}
             courseTitle={assessment.courseTitle}

--- a/app/courses/[courseId]/assessments/[assignmentId]/rubric/actions.ts
+++ b/app/courses/[courseId]/assessments/[assignmentId]/rubric/actions.ts
@@ -3,8 +3,10 @@
 import { revalidatePath } from "next/cache"
 import { and, eq } from "drizzle-orm"
 import { db } from "@/db/orm"
+import { syncQuestionMaxPointsWithRubric } from "@/lib/assessment-points"
 import { assignmentRubricItems, assignments, courseMemberships } from "@/db/schema"
 import { requireAppUser } from "@/lib/current-user"
+import { parseQuestionsJson } from "@/lib/questions"
 import {
   buildRubricFieldErrors,
   flattenRubricItems,
@@ -263,7 +265,7 @@ export async function updateRubricAction(
   }
 
   const existing = await db
-    .select({ id: assignments.id, totalPoints: assignments.totalPoints })
+    .select({ id: assignments.id, totalPoints: assignments.totalPoints, questionsJson: assignments.questionsJson })
     .from(assignments)
     .where(and(eq(assignments.id, assignmentId), eq(assignments.courseId, courseId)))
     .limit(1)
@@ -274,6 +276,13 @@ export async function updateRubricAction(
   }
 
   const totalMaxScore = getRubricTotalMaxScore(rubricJson)
+  const existingQuestionsPayload = parseQuestionsJson(assignment.questionsJson)
+  const syncedQuestionsJson = existingQuestionsPayload
+    ? {
+        ...existingQuestionsPayload,
+        questions: syncQuestionMaxPointsWithRubric(existingQuestionsPayload.questions, rubricJson),
+      }
+    : null
 
   const flattenedItems = flattenRubricItems(rubricJson)
 
@@ -289,7 +298,12 @@ export async function updateRubricAction(
   await db.transaction(async (tx) => {
     await tx
       .update(assignments)
-      .set({ rubricJson, totalPoints: totalMaxScore, updatedAt: new Date().toISOString() })
+      .set({
+        rubricJson,
+        questionsJson: syncedQuestionsJson ?? assignment.questionsJson,
+        totalPoints: totalMaxScore,
+        updatedAt: new Date().toISOString(),
+      })
       .where(and(eq(assignments.id, assignmentId), eq(assignments.courseId, courseId)))
 
     await tx.delete(assignmentRubricItems).where(eq(assignmentRubricItems.assignmentId, assignmentId))

--- a/lib/assessment-points.ts
+++ b/lib/assessment-points.ts
@@ -1,0 +1,37 @@
+import type { AssignmentQuestion } from "@/lib/questions"
+import type { RubricPayload } from "@/lib/rubrics"
+
+export function getRubricQuestionPointMap(rubric: RubricPayload | null | undefined) {
+  const pointMap = new Map<string, number>()
+
+  for (const question of rubric?.questions ?? []) {
+    const questionId = question.question_id.trim()
+    if (!questionId) continue
+
+    pointMap.set(
+      questionId,
+      question.rubric_items.reduce((sum, item) => sum + item.max_score, 0),
+    )
+  }
+
+  return pointMap
+}
+
+export function syncQuestionMaxPointsWithRubric(
+  questions: AssignmentQuestion[],
+  rubric: RubricPayload | null | undefined,
+) {
+  const pointMap = getRubricQuestionPointMap(rubric)
+
+  return questions.map((question) => {
+    const rubricPoints = pointMap.get(question.question_id.trim())
+    if (rubricPoints === undefined) {
+      return question
+    }
+
+    return {
+      ...question,
+      question_max_total: rubricPoints,
+    }
+  })
+}

--- a/lib/course-management.ts
+++ b/lib/course-management.ts
@@ -70,6 +70,7 @@ export type AssessmentRubricDetail = AssessmentDetail & {
 export type AssessmentQuestionsDetail = AssessmentDetail & {
   viewerRole: CourseViewerRole
   questionsJson: unknown | null
+  rubricJson: unknown | null
 }
 
 export type SubmissionSummary = {
@@ -403,6 +404,7 @@ export async function getAssessmentQuestionsForMember(
       courseId: courses.id,
       courseTitle: courses.title,
       questionsJson: assignments.questionsJson,
+      rubricJson: assignments.rubricJson,
       allowResubmissions: assignments.allowResubmissions,
       maxAttemptResubmission: assignments.maxAttemptResubmission,
       viewerRole: sql<CourseViewerRole>`case when ${myMembership.role} = 'student' then 'Student' else 'Instructor' end`,
@@ -434,6 +436,7 @@ export async function getAssessmentQuestionsForMember(
     courseId: Number(row.courseId),
     courseTitle: String(row.courseTitle),
     questionsJson: row.questionsJson ?? null,
+    rubricJson: row.rubricJson ?? null,
     allowResubmissions: Boolean(row.allowResubmissions),
     maxAttemptResubmission: Number(row.maxAttemptResubmission ?? 0),
     viewerRole: row.viewerRole === "Student" ? "Student" : "Instructor",

--- a/tests/assessments/assessment-questions-page.test.ts
+++ b/tests/assessments/assessment-questions-page.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   requireAppUser: vi.fn(),
   getAssessmentQuestionsForMember: vi.fn(),
   parseQuestionsJson: vi.fn(),
+  parseRubricJson: vi.fn(),
   notFound: vi.fn(() => {
     throw new Error("NOT_FOUND")
   }),
@@ -18,6 +19,7 @@ vi.mock("@/lib/course-management", () => ({
   getAssessmentQuestionsForMember: mocks.getAssessmentQuestionsForMember,
 }))
 vi.mock("@/lib/questions", () => ({ parseQuestionsJson: mocks.parseQuestionsJson }))
+vi.mock("@/lib/rubrics", () => ({ parseRubricJson: mocks.parseRubricJson }))
 vi.mock(
   "@/app/courses/[courseId]/assessments/[assignmentId]/questions/_components/question-editor",
   () => ({ QuestionEditor: mocks.QuestionEditor }),
@@ -37,6 +39,7 @@ function makeAssessment(overrides?: Record<string, unknown>) {
     courseId: 5,
     courseTitle: "CS101",
     questionsJson: null,
+    rubricJson: null,
     allowResubmissions: false,
     maxAttemptResubmission: 0,
     viewerRole: "Student" as "Student" | "Instructor",
@@ -66,6 +69,7 @@ describe("AssessmentQuestionsPage", () => {
     })
     mocks.QuestionEditor.mockReturnValue(null)
     mocks.parseQuestionsJson.mockReturnValue(null)
+    mocks.parseRubricJson.mockReturnValue(null)
   })
 
   // ── auth / ID validation ──────────────────────────────────────────────────
@@ -107,6 +111,13 @@ describe("AssessmentQuestionsPage", () => {
     expect(mocks.parseQuestionsJson).toHaveBeenCalledWith(questionsJson)
   })
 
+  it("passes rubricJson from the assessment to parseRubricJson", async () => {
+    const rubricJson = { questions: [{ question_id: "Q1", rubric_items: [{ criterion: "Correctness", max_score: 5 }] }] }
+    mocks.getAssessmentQuestionsForMember.mockResolvedValue(makeAssessment({ rubricJson }))
+    await AssessmentQuestionsPage({ params: Promise.resolve({ courseId: "5", assignmentId: "12" }) })
+    expect(mocks.parseRubricJson).toHaveBeenCalledWith(rubricJson)
+  })
+
   // ── student view — null questions ─────────────────────────────────────────
 
   it("renders 'No questions yet' and omits QuestionEditor when student has no saved questions", async () => {
@@ -138,15 +149,17 @@ describe("AssessmentQuestionsPage", () => {
 
   it("passes initialPayload from parseQuestionsJson to QuestionEditor", async () => {
     const payload = makeQuestionsPayload()
+    const rubric = { questions: [{ question_id: "Q1", rubric_items: [{ criterion: "Correctness", max_score: 5 }] }] }
     mocks.getAssessmentQuestionsForMember.mockResolvedValue(makeAssessment({ viewerRole: "Student" }))
     mocks.parseQuestionsJson.mockReturnValue(payload)
+    mocks.parseRubricJson.mockReturnValue(rubric as never)
 
     const element = await AssessmentQuestionsPage({
       params: Promise.resolve({ courseId: "5", assignmentId: "12" }),
     })
     renderToStaticMarkup(element as unknown as React.ReactElement)
 
-    expect(mocks.QuestionEditor.mock.calls[0][0]).toMatchObject({ initialPayload: payload })
+    expect(mocks.QuestionEditor.mock.calls[0][0]).toMatchObject({ initialPayload: payload, rubric })
   })
 
   // ── instructor view ───────────────────────────────────────────────────────

--- a/tests/assessments/question-editor.jest.test.tsx
+++ b/tests/assessments/question-editor.jest.test.tsx
@@ -80,6 +80,7 @@ function defaultEditorProps(overrides?: Record<string, unknown>) {
     courseId: 5,
     assignmentId: 12,
     initialPayload: null,
+    rubric: null,
     canEdit: true,
     assignmentTitle: "Midterm",
     courseTitle: "CS101",
@@ -173,6 +174,34 @@ describe("canEdit=false", () => {
     expect(container.textContent).toContain("15")
   })
 
+  test("shows rubric-derived points when a saved rubric overrides the question max", () => {
+    const payload = makePayload([
+      makeQuestion({ question_id: "Q1", question_text: "Explain recursion", question_max_total: 10 }),
+    ])
+    const rubric = {
+      questions: [
+        {
+          question_id: "Q1",
+          question_max_total: 5,
+          rubric_items: [{ criterion: "Correctness", explanation: "", max_score: 5 }],
+        },
+      ],
+      total_max_score: 5,
+      overall_feedback: "",
+    }
+
+    act(() => {
+      root.render(
+        <QuestionEditor
+          {...defaultEditorProps({ canEdit: false, initialPayload: payload, rubric })}
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain("5 pts")
+    expect(container.textContent).not.toContain("10 pts")
+  })
+
   test("no Save, Cancel, Edit questions, or Delete buttons are present for students", () => {
     const payload = makePayload([makeQuestion()])
     act(() => {
@@ -254,6 +283,37 @@ describe("canEdit=true with no saved questions (edit mode)", () => {
     })
     expect(container.textContent).toContain("Question 1")
     expect(container.textContent).not.toContain("Question 2")
+  })
+
+  test("locks max points to the rubric for matching question ids", () => {
+    const payload = makePayload([makeQuestion({ question_id: "Q1", question_max_total: 10 })])
+    const rubric = {
+      questions: [
+        {
+          question_id: "Q1",
+          question_max_total: 5,
+          rubric_items: [{ criterion: "Correctness", explanation: "", max_score: 5 }],
+        },
+      ],
+      total_max_score: 5,
+      overall_feedback: "",
+    }
+
+    act(() => {
+      root.render(<QuestionEditor {...defaultEditorProps({ initialPayload: payload, rubric })} />)
+    })
+
+    const editButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Edit questions",
+    ) as HTMLButtonElement
+    act(() => {
+      editButton.click()
+    })
+
+    const maxPointsInput = container.querySelector("#qmax-0") as HTMLInputElement
+    expect(maxPointsInput.value).toBe("5")
+    expect(maxPointsInput.disabled).toBe(true)
+    expect(container.textContent).toContain("Question max points are controlled by the saved rubric")
   })
 
   test("clicking Add question appends a second card", () => {

--- a/tests/assessments/save-questions-action.test.ts
+++ b/tests/assessments/save-questions-action.test.ts
@@ -330,4 +330,35 @@ describe("saveQuestionsAction", () => {
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/courses/5/assessments/12/questions")
     expect(mocks.revalidatePath).toHaveBeenCalledTimes(2)
   })
+
+  it("syncs question max totals from the saved rubric before persisting", async () => {
+    mocks.selectQueue.push(
+      [{ id: 99 }],
+      [
+        {
+          id: 12,
+          rubricJson: {
+            questions: [
+              {
+                question_id: "Q1",
+                rubric_items: [{ criterion: "Correctness", max_score: 5 }],
+              },
+            ],
+          },
+        },
+      ],
+      [{ title: "T", description: "", courseTitle: "C" }],
+    )
+
+    const result = await saveQuestionsAction({}, makeFormData({ questionsPayload: validPayload() }))
+
+    expect(result.savedQuestions?.[0].question_max_total).toBe(5)
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        questionsJson: expect.objectContaining({
+          questions: [expect.objectContaining({ question_id: "Q1", question_max_total: 5 })],
+        }),
+      }),
+    )
+  })
 })

--- a/tests/assessments/update-rubric-action.test.ts
+++ b/tests/assessments/update-rubric-action.test.ts
@@ -71,7 +71,7 @@ describe("updateRubricAction", () => {
   it("derives and saves assignment total points from the rubric sum", async () => {
     mocks.selectQueue.push(
       [{ id: 91 }],
-      [{ id: 12, totalPoints: 10 }],
+      [{ id: 12, totalPoints: 10, questionsJson: null }],
     )
 
     const formData = new FormData()
@@ -105,6 +105,50 @@ describe("updateRubricAction", () => {
     expect(mocks.txUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         totalPoints: 8,
+      }),
+    )
+  })
+
+  it("syncs saved question max totals from the rubric when questions already exist", async () => {
+    mocks.selectQueue.push(
+      [{ id: 91 }],
+      [
+        {
+          id: 12,
+          totalPoints: 10,
+          questionsJson: {
+            assignment_title: "Midterm",
+            course: "CS101",
+            instructions_summary: "",
+            questions: [{ question_id: "Q1", question_text: "Explain X", question_max_total: 10 }],
+          },
+        },
+      ],
+    )
+
+    const formData = new FormData()
+    formData.set("courseId", "5")
+    formData.set("assignmentId", "12")
+    formData.set(
+      "rubricPayload",
+      JSON.stringify({
+        questions: [
+          {
+            question_id: "Q1",
+            rubric_items: [{ criterion: "Correctness", rubric_name: "Correctness", max_score: 5 }],
+          },
+        ],
+      }),
+    )
+
+    await updateRubricAction({}, formData)
+
+    expect(mocks.txUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        questionsJson: expect.objectContaining({
+          questions: [expect.objectContaining({ question_id: "Q1", question_max_total: 5 })],
+        }),
+        totalPoints: 5,
       }),
     )
   })

--- a/tests/lib/get-assessment-questions-for-member.test.ts
+++ b/tests/lib/get-assessment-questions-for-member.test.ts
@@ -34,6 +34,7 @@ function makeAssessmentRow(overrides?: Record<string, unknown>) {
     courseId: 5,
     courseTitle: "CS101",
     questionsJson: null,
+    rubricJson: null,
     allowResubmissions: false,
     maxAttemptResubmission: null,
     viewerRole: "Student",
@@ -93,6 +94,15 @@ describe("getAssessmentQuestionsForMember", () => {
     mocks.selectQueue.push([makeAssessmentRow({ questionsJson, viewerRole: "Student" })])
     const result = await getAssessmentQuestionsForMember(42, 5, 12)
     expect(result?.questionsJson).toEqual(questionsJson)
+  })
+
+  it("returns rubricJson when the assignment has a saved rubric", async () => {
+    const rubricJson = {
+      questions: [{ question_id: "Q1", rubric_items: [{ criterion: "Correctness", max_score: 5 }] }],
+    }
+    mocks.selectQueue.push([makeAssessmentRow({ rubricJson, viewerRole: "Student" })])
+    const result = await getAssessmentQuestionsForMember(42, 5, 12)
+    expect(result?.rubricJson).toEqual(rubricJson)
   })
 
   it("maps all scalar fields correctly from the DB row", async () => {


### PR DESCRIPTION
## Linked User Story
- Closes #88 
- Story label on this PR: `story:<id>` (required for spec automation)

## Change Summary
- Backend:
  - Added a shared helper to derive per-question point totals from the saved rubric.
  - Updated question saves to sync `question_max_total` from the rubric before persisting `questionsJson`.
  - Updated rubric saves to also rewrite saved `questionsJson` so question max points stay aligned when rubric totals change.
  - Extended the questions page loader to include `rubricJson` alongside `questionsJson`.

- Frontend:
  - Passed saved rubric data into the Questions editor.
  - Made the Questions page display rubric-derived max points for matching question IDs instead of stale saved question totals.
  - Disabled manual editing of question max points when a matching saved rubric entry exists.
  - Added inline guidance explaining that rubric totals control grading points, plus a warning when a question has no matching rubric entry.

- Tests:
  - Added coverage for loading rubric data on the questions page.
  - Added server-action coverage for syncing question max totals on both question save and rubric save.
  - Added Questions editor coverage for showing rubric-derived totals and locking the max-points input when rubric values apply.

## Why
Previously the Questions editor and the saved rubric could disagree about how many points a question was worth. The assessment page and grading flow were already rubric-based, so instructors could see conflicting values across the UI. This change makes rubric totals the source of truth and keeps the saved question payload in sync.

## Testing
- `npm test -- tests/lib/get-assessment-questions-for-member.test.ts tests/assessments/assessment-questions-page.test.ts tests/assessments/save-questions-action.test.ts tests/assessments/update-rubric-action.test.ts`
- `npm run test:jest -- tests/assessments/question-editor.jest.test.tsx`

## Automated LLM Review Evidence
- [ ] I confirmed `LLM PR Review` workflow ran on this PR
- [ ] I reviewed the bot comment and captured any follow-up changes
- [ ] I documented where the review output appears (PR comment/check logs)

## Human Judgment and Approval
- [ ] Human reviewer validated correctness beyond LLM feedback
- [ ] Human reviewer approved merge decision
- Notes on how LLM output informed review:
  - Local tests covered the sync behavior in the question save path, rubric save path, questions page loading, and Questions editor UI state.

## Development Specification Automation
- [ ] On approval, `Dev Spec Automation On Approval` should run
- [ ] Result should appear as an auto-generated docs PR and linked tracking issue
- [ ] I verified the generated spec for accuracy before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Questions now automatically synchronize with rubric point values when a rubric is created or updated.
  * Rubric-derived points are displayed consistently across student views, instructor modes, and PDF downloads.

* **Bug Fixes**
  * Maximum point inputs are now locked when controlled by a rubric to prevent manual misalignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->